### PR TITLE
Fixed missing deallocate statement.

### DIFF
--- a/include/templates/vector_impl.inc
+++ b/include/templates/vector_impl.inc
@@ -637,6 +637,7 @@
              do i=1, this%vsize
                __TYPE_MOVE(__GET(temp(i)), __GET(this%elements(i)))
              end do
+	     deallocate(this%elements)
              call move_alloc(temp, this%elements)
            endif
          else if (allocated(this%elements)) then  ! capacity==0


### PR DESCRIPTION
Not sure why compilers silently failed during unit tests.  Was caught in use in real application.