### PR TITLE
Fix for bug with empty containers.

### DIFF
--- a/include/templates/altSet_impl.inc
+++ b/include/templates/altSet_impl.inc
@@ -830,7 +830,11 @@
       class(__iterator), target, intent(in) :: this
       __type_declare_result, pointer :: value
 
-      value=>this%reference%items%at(this%current)
+      if (this%current == UNINITIALIZED) then
+         value => null()
+      else
+         value=>this%reference%items%at(this%current)
+      end if
 
       end function __PROC(value)
 

--- a/include/templates/map_impl.inc
+++ b/include/templates/map_impl.inc
@@ -332,7 +332,11 @@
          type(__pair), pointer :: p
 
          p => this%setIter%value()
-         res => p%value
+         if (associated(p)) then
+            res => p%value
+         else
+            res => null()
+         end if
 
       end function __PROC(value)
 

--- a/include/templates/set_impl.inc
+++ b/include/templates/set_impl.inc
@@ -642,7 +642,11 @@
       class(__iterator), intent(in) :: this
       __type_declare_result, pointer :: value
 
-      value=>this%node%value
+      if (associated(this%node)) then
+         value =>this%node%value
+      else
+         value => null()
+      end if
 
       end function __PROC(value)
 

--- a/tests/Map/Test_Map.m4
+++ b/tests/Map/Test_Map.m4
@@ -104,6 +104,16 @@ contains
    end subroutine test_at
 
 @test
+   subroutine test_value_empty_is_null()
+      type (Map), target :: m
+      type (MapIterator) :: iter
+
+      iter = m%find(KEY1)
+      @assertFalse(associated(iter%value()))
+
+   end subroutine test_value_empty_is_null
+
+@test
    subroutine test_find()
       type (Map), target :: m
       type (MapIterator) :: iter


### PR DESCRIPTION
The value() method previously made illegal references when an iterator
is derived from an empty container.  (E.g., c%find(x)).

This was missed in the unit tests where the iterator was compared
against end().  But we expect value() to behave reasonably even in
this empty case.   Fixes for map, set, and alt_set containers.