### PR TITLE
Fixes #13.

### DIFF
--- a/include/templates/altSet_decl.inc
+++ b/include/templates/altSet_decl.inc
@@ -40,7 +40,9 @@
         procedure :: dump => __PROC(dump)
 !!$#endif
         procedure :: deepCopy => __PROC(deepCopy)
+#ifndef __ifort_18
         generic :: assignment(=) => deepCopy
+#endif
         procedure :: equalSets
         generic :: operator(==) => equalSets
         procedure :: notEqualSets

--- a/include/templates/set_decl.inc
+++ b/include/templates/set_decl.inc
@@ -46,7 +46,9 @@
         procedure :: dump => __PROC(dump)
 #endif
         procedure :: deepCopy => __PROC(deepCopy)
+#ifndef __ifort_18
         generic :: assignment(=) => deepCopy
+#endif
         procedure :: equalSets
         generic :: operator(==) => equalSets
         procedure :: notEqualSets

--- a/include/templates/vector_decl.inc
+++ b/include/templates/vector_decl.inc
@@ -66,7 +66,9 @@
 
 #ifndef __type_wrapped
          procedure :: copyFromArray => __PROC(copyfromarray)
+#ifndef __ifort_18         
          generic :: assignment(=) => copyFromArray
+#endif
 #endif
          procedure :: push_back => __PROC(push_back)
          procedure :: pop_back => __PROC(pop_back)


### PR DESCRIPTION
This commit deactivates a bit of gFTL that breaks with ifort 18.  The
capability is for copying vectors and is mostly there to keep the interfaces
as close to STL as possible.

By default this commit does not change anything.  But if the user
specifies __INTEL_18 as an FPP token, then the offending logic is skipped
.