### PR TITLE
Undo some of previous workaround.

### DIFF
--- a/include/templates/set_decl.inc
+++ b/include/templates/set_decl.inc
@@ -46,9 +46,8 @@
         procedure :: dump => __PROC(dump)
 #endif
         procedure :: deepCopy => __PROC(deepCopy)
-#ifndef __ifort_18
         generic :: assignment(=) => deepCopy
-#endif
+
         procedure :: equalSets
         generic :: operator(==) => equalSets
         procedure :: notEqualSets


### PR DESCRIPTION
Previous workarounds for ifort 18 were more pervasive than necassary.
This change reactivates the ASSIGNMENT(=) operator for Set containers
(not altSet).

No consequence at all if not using __ifort_18 flag.