### PR TITLE
Fixes #26 - workaround for compiler bug in NAG Fortran 6221.

### DIFF
--- a/cmake_utils/NAG.cmake
+++ b/cmake_utils/NAG.cmake
@@ -1,8 +1,7 @@
-# Compiler specific flags for Intel Fortran compiler
+# Compiler specific flags for NAG Fortran compiler
 
 set(no_optimize "-O0")
-#set(check_all "-C=all")
-set(check_all "-C=array -C=alias -C=bits -C=calls -C=do -C=intovf -C=present -C=pointer")
+set(check_all "-C=all")
 set(cpp "-fpp")
 set(suppress_fpp_warnings "-w")
 

--- a/cmake_utils/PGI.cmake
+++ b/cmake_utils/PGI.cmake
@@ -1,0 +1,10 @@
+# Compiler specific flags for PGI Fortran compiler
+# (or is this now NVIDIA?)
+
+set(traceback "-traceback")
+set(check_all "-Mbounds -Mchkfpstk -Mchkstk")
+
+set(CMAKE_Fortran_FLAGS_DEBUG  "-O0")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_Fortran_FLAGS "-g ${traceback} ${check_all} -Mallocatable=03")
+

--- a/include/templates/vector_impl.inc
+++ b/include/templates/vector_impl.inc
@@ -436,8 +436,10 @@
 
          n = this%vsize
          if (index==n+1) then
-           call this%push_back(value)
-           return
+            call this%push_back(value)
+            ! Workaround for NAG -6221 - temp needs some status
+            __TYPE_ASSIGN(temp,value)
+            return
          endif
          call this%grow_to(this%vsize+1)
          __TYPE_ASSIGN(temp,__GET(this%elements(n)))

--- a/tests/Map/Test_Map.m4
+++ b/tests/Map/Test_Map.m4
@@ -134,7 +134,7 @@ contains
 
 @test
    subroutine test_erase()
-      type (Map) :: m
+      type (Map), target :: m
       type (MapIterator) :: iter
 
       call m%insert(KEY1, ONE)
@@ -148,7 +148,7 @@ contains
 
 @test
    subroutine test_next()
-      type (Map) :: m
+      type (Map), target :: m
       type (MapIterator) :: iter
 
       __value_declare_result, pointer :: q1, q2, q3
@@ -173,7 +173,7 @@ contains
 
 @test
    subroutine test_previous()
-      type (Map) :: m
+      type (Map), target :: m
       type (MapIterator) :: iter
 
       __value_declare_result, pointer :: q1, q2, q3
@@ -200,7 +200,7 @@ contains
 
 @test
    subroutine test_iterGetValue()
-      type (Map) :: m
+      type (Map), target :: m
       type (MapIterator) :: iter
 
       __value_declare_result, pointer :: q1, q2, q3

--- a/tests/Set/Test_Set.m4
+++ b/tests/Set/Test_Set.m4
@@ -218,6 +218,17 @@ contains
 #endif
 
 @test
+   subroutine test_iterator_empty()
+      type (Set), target :: s
+      type (SetIterator) :: iter
+
+      iter = s%begin()
+      @assertFalse(associated(iter%value()))
+
+   end subroutine test_iterator_empty
+
+
+@test
    subroutine test_eraseOne()
       type (Set), target :: s
       type (SetIterator) :: iter

--- a/tests/altSet/Test_altSet.m4
+++ b/tests/altSet/Test_altSet.m4
@@ -307,6 +307,17 @@ contains
 
 
 @test
+   subroutine test_iterator_empty()
+      type (Set), target :: s
+      type (SetIterator) :: iter
+
+      iter = s%begin()
+      @assertFalse(associated(iter%value()))
+
+   end subroutine test_iterator_empty
+
+
+@test
    subroutine test_equal()
       type (Set), target :: a, b
 


### PR DESCRIPTION
A ticket has been opened with NAG.  Preliminary analysis shows that it
is related to an allocatable polymorphic local variable that is unused
for some branches.  The workaround is to allocate it even when
unnecessary.


Various other improvements in this commit:

 - Added a PGI.cmake, but PGI cannot yet build the current version.
 - Bumped NAG.cmake to use -C=all, which includes -C=dangling Added
 - necessary TARGET attributes in tests that were exposed by the
   -C=dangling change in the previous bullet.
 - Added unit tests for Set iterators on empty Set containers.  Had
   forgotten this was already fixed, and had a user stumble against it
   using an older version of gFTL.