### PR TITLE
Fixes #25 - robust targets in containers.

### DIFF
--- a/cmake_utils/PGI.mk
+++ b/cmake_utils/PGI.mk
@@ -1,0 +1,10 @@
+# Compiler specific flags for Intel Fortran compiler
+
+set(no_optimize "-O0")
+set(check_all "-C=all")
+set(cpp "-fpp")
+
+
+set(CMAKE_Fortran_FLAGS_DEBUG  "${no_optimize}")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_Fortran_FLAGS "-g ${cpp} ${traceback} ${check_all}")

--- a/include/templates/vector_impl.inc
+++ b/include/templates/vector_impl.inc
@@ -445,10 +445,10 @@
          __TYPE_ASSIGN(temp,__GET(this%elements(n)))
          call this%resize(n+1, temp, rc=rc)
          
-         do i = n-1, index, -1
+         do i = n, index, -1
           __TYPE_MOVE(__GET(this%elements(i+1)),__GET(this%elements(i)))
          end do
-         
+
          __TYPE_ASSIGN(__GET(this%elements(index)), value)
          
          return

--- a/tests/Map/CMakeLists.txt
+++ b/tests/Map/CMakeLists.txt
@@ -107,6 +107,14 @@ endforeach ()
 list (APPEND SRCS AuxTest.F90)
 
 add_custom_command (
+  OUTPUT Test_map_Allocatable.F90
+  COMMAND ${PFUNIT}/bin/pFUnitParser.py ${src}/Test_map_Allocatable.pf Test_map_Allocatable.F90
+  WORKING_DIRECTORY ${bin}
+  DEPENDS ${src}/Test_map_Allocatable.pf
+  )
+list(APPEND SRCS Test_map_Allocatable.F90)
+
+add_custom_command (
     OUTPUT AuxTest.F90
     COMMAND ${PFUNIT}/bin/pFUnitParser.py ${src}/AuxTest.pf AuxTest.F90
     WORKING_DIRECTORY ${bin}

--- a/tests/Map/Test_map_Allocatable.pf
+++ b/tests/Map/Test_map_Allocatable.pf
@@ -1,0 +1,60 @@
+! If a container is for allocatable entities, then gFTL should enable
+! external pointers into the structure to persist even when the
+! container is modified.  This relies on Fortran's move_alloc()
+! behavior, and thus cannot be supported for non allocatable container
+! elements.
+
+
+module MyMap_mod
+   use Foo_mod
+#include "types/key_deferredLengthString.inc"
+#include "types/value_FooPoly.inc"
+#define _alt
+#define _pair_allocatable
+#include "templates/map.inc"
+end module MyMap_mod
+
+
+module Test_map_Allocatable_mod
+   use pFUnit_mod
+   use MyMap_mod
+   use Foo_mod
+
+   @suite(name='Test_map_allocatable_suite')
+
+contains
+
+
+   @test
+   subroutine test_insert()
+      type (Map), target :: m
+      class (Foo), pointer :: pa, pb, pc
+
+      ! Try to insert in non canonical order so that things must move
+      ! But in the worst case, the fact that we have 5 elements should
+      ! cause some move_alloc() when internals are copied.
+
+      call m%insert('c',Foo(3))
+      pc => m%at('c')
+      call m%insert('b',Foo(2))
+      pb => m%at('b')
+      call m%insert('a',Foo(1))
+      pa => m%at('a')
+
+      ! Sanity checks
+      @assertEqual(1, pa%i)
+      @assertEqual(2, pb%i)
+      @assertEqual(3, pc%i)
+
+      call m%insert('A',Foo(4))
+      call m%insert('B',Foo(5))
+      call m%insert('C',Foo(6))
+
+      ! Pointers still valid?
+      @assertEqual(1, pa%i)
+      @assertEqual(2, pb%i)
+      @assertEqual(3, pc%i)
+   end subroutine test_insert
+
+
+end module Test_map_Allocatable_mod

--- a/tests/Map/altMapTestSuites.inc
+++ b/tests/Map/altMapTestSuites.inc
@@ -30,3 +30,5 @@ ADD_TEST_SUITE(Test_integer1dinteger1daltMap_mod_suite)
   ADD_TEST_SUITE(Test_deferredLengthStringdeferredLengthStringaltMap_mod_suite)
 #endif
 
+! Test for robust pointers to allocatable components
+ADD_TEST_SUITE(Test_map_Allocatable_suite)

--- a/tests/Vector/CMakeLists.txt
+++ b/tests/Vector/CMakeLists.txt
@@ -89,6 +89,14 @@ foreach (type ${types} )
 
 endforeach ()
 
+add_custom_command (
+  OUTPUT Test_vector_Allocatable.F90
+  COMMAND ${PFUNIT}/bin/pFUnitParser.py ${src}/Test_vector_Allocatable.pf Test_vector_Allocatable.F90
+  WORKING_DIRECTORY ${bin}
+  DEPENDS ${src}/Test_vector_Allocatable.pf
+  )
+list(APPEND SRCS Test_vector_Allocatable.F90)
+
 add_library (testVector STATIC EXCLUDE_FROM_ALL ${SRCS})
 target_link_libraries (testVector shared vectorSUT pfunit)
 add_dependencies (testVector types)

--- a/tests/Vector/Test_vector_Allocatable.pf
+++ b/tests/Vector/Test_vector_Allocatable.pf
@@ -1,0 +1,36 @@
+! If a container is for allocatable entities, then gFTL should enable
+! external pointers into the structure to persist even when the
+! container is modified.  This relies on Fortran's move_alloc()
+! behavior, and thus cannot be supported for non allocatable container
+! elements.
+
+module Test_vector_Allocatable_mod
+   use pFUnit_mod
+   use FooPolyVector_mod
+   use Foo_mod
+
+contains
+
+   @test
+   subroutine test_insert()
+      type (Vector), target :: v
+      class (Foo), pointer :: p1, p2
+
+      call v%push_back(Foo(1))
+      p1 => v%at(1)
+      call v%insert(1, Foo(2))
+
+      ! Verify that 1st element has changed
+      p2 => v%at(1)
+      @assertEqual(2, p2%i)
+
+      ! Verify that p1 still points at correct target
+      @assertEqual(1, p1%i)
+      p2 => v%at(2)
+      @assertEqual(1, p2%i)
+      @assertTrue(associated(p1, p2))
+
+   end subroutine test_insert
+
+
+end module Test_vector_Allocatable_mod

--- a/tests/Vector/vectorTestSuites.inc
+++ b/tests/Vector/vectorTestSuites.inc
@@ -43,3 +43,5 @@ ADD_TEST_SUITE(Test_UnlimitedPolyPtrVector_mod_suite)
 ! Test for broken intel 18 behavior with nested containers  
 ADD_MODULE_TEST_SUITE(Test_Nested_mod, Test_nested_suite)
   
+! Test for robust pointers to allocatable components
+ADD_TEST_SUITE(Test_vector_Allocatable_mod_suite)

--- a/tests/altSet/CMakeLists.txt
+++ b/tests/altSet/CMakeLists.txt
@@ -77,6 +77,13 @@ foreach (type ${types} )
 
 endforeach ()
 
+add_custom_command (
+  OUTPUT Test_altSet_Allocatable.F90
+  COMMAND ${PFUNIT}/bin/pFUnitParser.py ${src}/Test_altSet_Allocatable.pf Test_altSet_Allocatable.F90
+  WORKING_DIRECTORY ${bin}
+  DEPENDS ${src}/Test_altSet_Allocatable.pf
+  )
+list(APPEND SRCS Test_altSet_Allocatable.F90)
 
 
 add_library (testaltSet STATIC EXCLUDE_FROM_ALL ${SRCS})

--- a/tests/altSet/Test_altSet_Allocatable.pf
+++ b/tests/altSet/Test_altSet_Allocatable.pf
@@ -1,0 +1,50 @@
+! If a container is for allocatable entities, then gFTL should enable
+! external pointers into the structure to persist even when the
+! container is modified.  This relies on Fortran's move_alloc()
+! behavior, and thus cannot be supported for non allocatable container
+! elements.
+
+module Test_altSet_Allocatable_mod
+   use pFUnit_mod
+   use FooPolyaltSet_mod
+   use Foo_mod
+
+contains
+
+   @test
+   subroutine test_insert()
+      type (Set), target :: s
+      class (Foo), pointer :: pa, pb, pc
+      type (SetIterator) :: iter
+      
+      call s%insert(Foo(3))
+      iter = s%begin()
+      pc => iter%value()
+      
+      call s%insert(Foo(2))
+      iter = s%begin()
+      pb => iter%value()
+
+      call s%insert(Foo(1))
+      iter = s%begin()
+      pa => iter%value()
+
+      ! Sanity checks
+      @assertEqual(1, pa%i)
+      @assertEqual(2, pb%i)
+      @assertEqual(3, pc%i)
+
+      call s%insert(Foo(5))
+      call s%insert(Foo(6))
+      call s%insert(Foo(-7))
+      call s%insert(Foo(-8))
+
+      ! Pointers still valid?
+      @assertEqual(1, pa%i)
+      @assertEqual(2, pb%i)
+      @assertEqual(3, pc%i)
+
+   end subroutine test_insert
+
+
+end module Test_altSet_Allocatable_mod

--- a/tests/altSet/altSetTestSuites.inc
+++ b/tests/altSet/altSetTestSuites.inc
@@ -35,3 +35,5 @@ ADD_TEST_SUITE(Test_FooPolyPtraltSet_mod_suite)
 ADD_TEST_SUITE(Test_unlimitedPolyPtraltSet_mod_suite)
 #endif
 
+! Test for robust pointers to allocatable components
+ADD_TEST_SUITE(Test_altSet_Allocatable_mod_suite)


### PR DESCRIPTION
When containers hold values with the ALLOCATABLE attribute, they
should be able support external pointers that remain valid as the
container changes.  The key is ensure that MOVE_ALLOC() is used in all
relevant cases instead of assignment.

For Vector containers this is mostly in place, but testing did reveal
a bug in the insert() method that is fixed here.


For altSet the functionality was also already present, apparently.
Presumably for Set it is trivial as Set uses pointers internally anway.

For (alt) Map, the functionality was latent.  Users must specify
_pair_allocatable so that altSet switches to MOVE_ALLOC()


Unfortunately, the truly desirable capability would be the case where
a map uses values that are ALLOCATABLE without regard to the key.
altSet would then need to MOVE_ALLOC() the value subcomponent of its
type, which is more intrusive than would otherwise be desirable.

And one might want key's to be preserved as well, at which point
_pair_allocatable is a fine solution.  So we will hold here for now.