### PR TITLE
Allow tests to work when included as subdirectory.

### DIFF
--- a/cmake_utils/CheckCompilerCapabilities.cmake
+++ b/cmake_utils/CheckCompilerCapabilities.cmake
@@ -1,22 +1,22 @@
 include (cmake_utils/CheckFortranSource.cmake)
 
 CHECK_Fortran_SOURCE_COMPILE (
-  ${CMAKE_SOURCE_DIR}/cmake_utils/pointerToFixedLengthString.F90
+  ${CMAKE_CURRENT_LIST_DIR}/pointerToFixedLengthString.F90
   SUPPORT_FOR_POINTERS_TO_FIXED_LENGTH_STRINGS
 )
 
 CHECK_Fortran_SOURCE_RUN (
-  ${CMAKE_SOURCE_DIR}/cmake_utils/pointerToDeferredLengthString.F90
+  ${CMAKE_CURRENT_LIST_DIR}/pointerToDeferredLengthString.F90
   SUPPORT_FOR_POINTERS_TO_DEFERRED_LENGTH_STRINGS
 )
 
 CHECK_Fortran_SOURCE_RUN (
-  ${CMAKE_SOURCE_DIR}/cmake_utils/supportsInt64.F90
+  ${CMAKE_CURRENT_LIST_DIR}/supportsInt64.F90
   SUPPORT_FOR_INT64
 )
 
 CHECK_Fortran_SOURCE_COMPILE (
-  ${CMAKE_SOURCE_DIR}/cmake_utils/supportsQuadPrecision.F90
+  ${CMAKE_CURRENT_LIST_DIR}/supportsQuadPrecision.F90
   SUPPORT_FOR_QUAD_PRECISION
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,3 +36,5 @@ set(driver ${PFUNIT}/include/driver.F90)
 add_executable(tests.x EXCLUDE_FROM_ALL ${driver})
 target_link_libraries(tests.x testVector vectorSUT testaltSet altsetSUT testSet setSUT testMap mapSUT shared pfunit)
 add_custom_target(tests COMMAND tests.x DEPENDS tests.x)
+add_dependencies(tests tests.x)
+

--- a/tests/Map/CMakeLists.txt
+++ b/tests/Map/CMakeLists.txt
@@ -5,25 +5,6 @@ include_directories (${PFUNIT}/include)
 include_directories (${PFUNIT}/mod)
 link_directories(${PFUNIT}/lib)
 
-include_directories (${CMAKE_CURRENT_SOURCE_DIR})
-include_directories (${CMAKE_CURRENT_BINARY_DIR}/SUT)
-
-
-include_directories(${GFTL_BINARY_DIR}/tests/shared)
-file(RELATIVE_PATH INCLUDE_RELATIVE_PATH_BIN
-     ${CMAKE_CURRENT_SOURCE_DIR}
-     ${CMAKE_BINARY_DIR}/.)
-file(RELATIVE_PATH INCLUDE_RELATIVE_PATH_SRC
-     ${CMAKE_CURRENT_SOURCE_DIR}
-     ${CMAKE_SOURCE_DIR}/.)
-
-include_directories (${INCLUDE_RELATIVE_PATH_BIN}/include)
-include_directories (${INCLUDE_RELATIVE_PATH_SRC}/include)
-include_directories(${INCLUDE_RELATIVE_PATH_BIN}/tests/include)
-include_directories (${CMAKE_SOURCE_DIR}/include)
-include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include)
-
-
 
 set (src ${CMAKE_CURRENT_SOURCE_DIR})
 set (bin ${CMAKE_CURRENT_BINARY_DIR})
@@ -122,11 +103,13 @@ add_custom_command (
     )
 
 add_library(testMap STATIC EXCLUDE_FROM_ALL ${SRCS})
+target_include_directories (testMap PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories (testMap PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(testMap mapSUT pfunit)
 add_dependencies(testMap type_test_values)
 
 set(driver ${PFUNIT}/include/driver.F90)
 add_executable(maptests.x EXCLUDE_FROM_ALL ${driver})
-target_link_libraries(maptests.x pfunit testMap mapSUT shared)
+target_link_libraries(maptests.x testMap)
 add_custom_target(maptests COMMAND maptests.x DEPENDS maptests.x)
 

--- a/tests/Map/SUT/CMakeLists.txt
+++ b/tests/Map/SUT/CMakeLists.txt
@@ -34,12 +34,6 @@ set (instantiations
   "deferredLengthString\;deferredLengthString\;free"
 )
 
-include_directories(${GFTL_BINARY_DIR}/tests/shared)
-include_directories (${GFTL_SOURCE_DIR}/include)
-include_directories (${GFTL_BINARY_DIR}/include)
-include_directories (${PFUNIT}/mod)
-
-
 set (SRCS)
 set (altSRCS)
 set (infile ${src}/Map.m4)
@@ -84,4 +78,6 @@ endforeach ()
 list (APPEND SRCS MultiModule.F90)
 
 add_library(mapSUT STATIC EXCLUDE_FROM_ALL ${SRCS} ${altSRCS})
-add_dependencies(mapSUT shared gftl)
+target_include_directories (mapSUT PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories (mapSUT PRIVATE ${PFUNIT}/mod)
+target_link_libraries(mapSUT type_test_values shared gftl)

--- a/tests/Set/CMakeLists.txt
+++ b/tests/Set/CMakeLists.txt
@@ -5,25 +5,6 @@ include_directories (${PFUNIT}/include)
 include_directories (${PFUNIT}/mod)
 link_directories(${PFUNIT}/lib)
 
-include_directories (${CMAKE_CURRENT_SOURCE_DIR})
-include_directories (${GFTL_BINARY_DIR}/tests/shared)
-
-include_directories (${GFTL_SOURCE_DIR}/include)
-include_directories (${GFTL_BINARY_DIR}/include)
-include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include)
-include_directories (${CMAKE_CURRENT_BINARY_DIR}/SUT)
-
-
-
-include_directories(${GFTL_BINARY_DIR}/tests/shared)
-# Use relative paths for includes so that CMake correctly
-# detects the need to generate include files.
-file(RELATIVE_PATH INCLUDE_RELATIVE_PATH_BIN
-     ${CMAKE_CURRENT_SOURCE_DIR}
-     ${CMAKE_BINARY_DIR}/.)
-include_directories(${INCLUDE_RELATIVE_PATH_BIN}/tests/include)
-include_directories(${INCLUDE_RELATIVE_PATH_BIN}/include)
-
 
 set (src ${CMAKE_CURRENT_SOURCE_DIR})
 set (bin ${CMAKE_CURRENT_BINARY_DIR})
@@ -71,7 +52,7 @@ foreach (type ${types} )
 
   add_custom_command (
     OUTPUT ${outfile}
-    COMMAND m4 -s -Dparam=${type} -I${CMAKE_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
+    COMMAND m4 -s -Dparam=${type} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
     COMMAND ${PFUNIT}/bin/pFUnitParser.py ${pfunitfile} ${outfile}
     WORKING_DIRECTORY ${bin}
     DEPENDS ${infile}
@@ -84,11 +65,12 @@ endforeach ()
 
 
 add_library (testSet STATIC EXCLUDE_FROM_ALL ${SRCS})
-target_link_libraries (testSet shared setSUT pfunit)
-add_dependencies (testSet type_test_values)
+target_include_directories (testSet PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories (testSet PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries (testSet setSUT pfunit)
 
 set (driver ${PFUNIT}/include/driver.F90)
 add_executable (settests.x EXCLUDE_FROM_ALL ${driver})
-target_link_libraries (settests.x  pfunit testSet setSUT shared)
+target_link_libraries (settests.x  pfunit testSet)
 add_custom_target (settests COMMAND settests.x DEPENDS settests.x EXCLUDE_FROM_ALL)
 

--- a/tests/Set/SUT/CMakeLists.txt
+++ b/tests/Set/SUT/CMakeLists.txt
@@ -1,9 +1,5 @@
 include_directories (${PFUNIT}/mod)
 
-include_directories (${GFTL_SOURCE_DIR}/include)
-include_directories (${GFTL_BINARY_DIR}/include)
-include_directories (${GFTL_BINARY_DIR}/tests/shared)
-
 set (instantiations
 
   "integer\;free"
@@ -72,4 +68,6 @@ endforeach ()
 list (APPEND SRCS MultiModule.F90)
 
 add_library(setSUT STATIC EXCLUDE_FROM_ALL ${SRCS})
-add_dependencies(setSUT shared gftl)
+target_include_directories (setSUT PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories (setSUT PRIVATE ${PFUNIT}/mod)
+target_link_libraries(setSUT type_test_values shared gftl)

--- a/tests/Vector/CMakeLists.txt
+++ b/tests/Vector/CMakeLists.txt
@@ -4,21 +4,6 @@ include_directories  (${PFUNIT}/include)
 include_directories  (${PFUNIT}/mod)
 link_directories (${PFUNIT}/lib)
 
-include_directories  (${CMAKE_CURRENT_SOURCE_DIR})
-include_directories  (${GFTL_SOURCE_DIR}/include)
-include_directories  (${CMAKE_CURRENT_SOURCE_DIR}/include)
-include_directories  (${GFTL_BINARY_DIR}/include)
-include_directories  (${GFTL_BINARY_DIR}/mod)
-include_directories  (${CMAKE_CURRENT_BINARY_DIR}/SUT)
-include_directories (${GFTL_BINARY_DIR}/tests/shared)
-
-file (RELATIVE_PATH INCLUDE_RELATIVE_PATH_BIN
-     ${CMAKE_CURRENT_SOURCE_DIR}
-     ${CMAKE_BINARY_DIR}/.)
-include_directories (${INCLUDE_RELATIVE_PATH_BIN}/include)
-include_directories (${INCLUDE_RELATIVE_PATH_BIN}/tests/include)
-
-
 set (src ${CMAKE_CURRENT_SOURCE_DIR})
 set (bin ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -65,7 +50,7 @@ foreach (type ${types} )
 
   add_custom_command (
     OUTPUT ${outfile}
-    COMMAND m4 -s -Dparam=${type} -I${CMAKE_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
+    COMMAND m4 -s -Dparam=${type} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
     COMMAND ${PFUNIT}/bin/pFUnitParser.py ${pfunitfile} ${outfile}
     WORKING_DIRECTORY ${bin}
     DEPENDS ${infile}
@@ -79,7 +64,7 @@ foreach (type ${types} )
 
   add_custom_command (
     OUTPUT ${outfile}
-    COMMAND m4 -s -Dparam=${type} -I${CMAKE_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
+    COMMAND m4 -s -Dparam=${type} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
     COMMAND ${PFUNIT}/bin/pFUnitParser.py ${pfunitfile} ${outfile}
     WORKING_DIRECTORY ${bin}
     DEPENDS ${infile}
@@ -98,9 +83,11 @@ add_custom_command (
 list(APPEND SRCS Test_vector_Allocatable.F90)
 
 add_library (testVector STATIC EXCLUDE_FROM_ALL ${SRCS})
-target_link_libraries (testVector shared vectorSUT pfunit)
-add_dependencies (testVector gftl)
+target_include_directories (testVector PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories (testVector PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries (testVector vectorSUT pfunit)
 add_dependencies (testVector type_test_values)
+
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
   if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
     if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER 17)
@@ -112,6 +99,6 @@ endif()
 
 set (driver ${PFUNIT}/include/driver.F90)
 add_executable (vectortests.x EXCLUDE_FROM_ALL ${driver})
-target_link_libraries (vectortests.x pfunit testVector vectorSUT shared)
+target_link_libraries (vectortests.x testVector)
 add_custom_target (vectortests COMMAND vectortests.x DEPENDS vectortests.x EXCLUDE_FROM_ALL)
 

--- a/tests/Vector/SUT/CMakeLists.txt
+++ b/tests/Vector/SUT/CMakeLists.txt
@@ -1,9 +1,3 @@
-include_directories (${GFTL_SOURCE_DIR}/include)
-include_directories (${GFTL_BINARY_DIR}/include)
-include_directories (${GFTL_BINARY_DIR}/mod)
-include_directories(${GFTL_BINARY_DIR}/tests/shared)
-include_directories (${PFUNIT}/mod)
-
 set(src ${CMAKE_CURRENT_SOURCE_DIR})
 set(bin ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -72,4 +66,6 @@ endforeach ()
 list (APPEND SRCS MultiModule.F90)
 
 add_library(vectorSUT EXCLUDE_FROM_ALL STATIC ${SRCS})
-add_dependencies(vectorSUT shared gftl )
+target_include_directories (vectorSUT PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories (vectorSUT PRIVATE ${PFUNIT}/mod)
+target_link_libraries(vectorSUT type_test_values shared gftl)

--- a/tests/altSet/CMakeLists.txt
+++ b/tests/altSet/CMakeLists.txt
@@ -5,26 +5,6 @@ include_directories (${PFUNIT}/include)
 include_directories (${PFUNIT}/mod)
 link_directories(${PFUNIT}/lib)
 
-include_directories (${CMAKE_CURRENT_SOURCE_DIR})
-include_directories (${GFTL_BINARY_DIR}/tests/shared)
-
-include_directories (${GFTL_SOURCE_DIR}/include)
-include_directories (${GFTL_BINARY_DIR}/include)
-include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include)
-include_directories (${CMAKE_CURRENT_BINARY_DIR}/SUT)
-
-
-
-include_directories(${GFTL_BINARY_DIR}/tests/shared)
-# Use relative paths for includes so that CMake correctly
-# detects the need to generate include files.
-file(RELATIVE_PATH INCLUDE_RELATIVE_PATH_BIN
-     ${CMAKE_CURRENT_SOURCE_DIR}
-     ${CMAKE_BINARY_DIR}/.)
-include_directories(${INCLUDE_RELATIVE_PATH_BIN}/tests/include)
-include_directories(${INCLUDE_RELATIVE_PATH_BIN}/include)
-
-
 set (src ${CMAKE_CURRENT_SOURCE_DIR})
 set (bin ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -67,7 +47,7 @@ foreach (type ${types} )
 
   add_custom_command (
     OUTPUT ${outfile}
-    COMMAND m4 -s -Dparam=${type} -I${CMAKE_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
+    COMMAND m4 -s -Dparam=${type} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
     COMMAND ${PFUNIT}/bin/pFUnitParser.py ${pfunitfile} ${outfile}
     WORKING_DIRECTORY ${bin}
     DEPENDS ${infile}
@@ -87,11 +67,14 @@ list(APPEND SRCS Test_altSet_Allocatable.F90)
 
 
 add_library (testaltSet STATIC EXCLUDE_FROM_ALL ${SRCS})
-target_link_libraries (testaltSet shared altsetSUT pfunit)
+target_include_directories (testaltSet PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories (testaltSet PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries (testaltSet altsetSUT pfunit)
 add_dependencies (testaltSet type_test_values)
+
 
 set (driver ${PFUNIT}/include/driver.F90)
 add_executable (setalttests.x EXCLUDE_FROM_ALL ${driver})
-target_link_libraries (setalttests.x  pfunit testaltSet altsetSUT shared)
+target_link_libraries (setalttests.x  testaltSet pfunit)
 add_custom_target (setalttests COMMAND setalttests.x DEPENDS setalttests.x EXCLUDE_FROM_ALL)
 

--- a/tests/altSet/SUT/CMakeLists.txt
+++ b/tests/altSet/SUT/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories (${PFUNIT}/mod)
 
-include_directories (${GFTL_SOURCE_DIR}/include)
-include_directories (${GFTL_BINARY_DIR}/include)
+#include_directories (${GFTL_SOURCE_DIR}/include)
+#include_directories (${GFTL_BINARY_DIR}/include)
 include_directories (${GFTL_BINARY_DIR}/tests/shared)
 
 set (instantiations
@@ -71,4 +71,6 @@ endforeach ()
 list (APPEND SRCS MultiModule.F90)
 
 add_library(altsetSUT STATIC EXCLUDE_FROM_ALL ${SRCS})
-add_dependencies(altsetSUT shared gftl)
+target_include_directories (altsetSUT PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories (altsetSUT PRIVATE ${PFUNIT}/mod)
+target_link_libraries(altsetSUT type_test_values shared gftl)

--- a/tests/include/CMakeLists.txt
+++ b/tests/include/CMakeLists.txt
@@ -1,1 +1,4 @@
+add_library (type_test_values INTERFACE)
+target_include_directories (type_test_values INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
+
 add_subdirectory (type_test_values) 

--- a/tests/include/type_test_values/CMakeLists.txt
+++ b/tests/include/type_test_values/CMakeLists.txt
@@ -48,7 +48,7 @@ foreach( macro_file ${macro_files} )
 
     add_custom_command(
 	OUTPUT ${outfile}
-	COMMAND m4 -s -Dparam=${param} -I${CMAKE_SOURCE_DIR}/include/templates < ${infile} > ${outfile}
+	COMMAND m4 -s -Dparam=${param} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${outfile}
 	WORKING_DIRECTORY ${bin}
 	DEPENDS ${infile}
 	)
@@ -58,6 +58,7 @@ foreach( macro_file ${macro_files} )
   endforeach()
 endforeach()
 
-add_custom_target( type_test_values
+add_custom_target (make_type_test_values
   DEPENDS ${depends}
   )
+add_dependencies (type_test_values make_type_test_values)

--- a/tests/shared/CMakeLists.txt
+++ b/tests/shared/CMakeLists.txt
@@ -4,8 +4,8 @@ set (SRCS
   pFUnitSupplement.F90
 )
 
-include_directories (${gFTL_SOURCE_DIR}/include)
-include_directories (${gFTL_BINARY_DIR}/include)
-include_directories (${PFUNIT}/mod)
-
 add_library(shared ${SRCS})
+target_include_directories (shared PRIVATE ${PFUNIT}/mod)
+target_include_directories (shared PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(shared gftl)
+


### PR DESCRIPTION
Also cleaned up CMakeLists.txt files in tests to reflect improved
understanding of target_include_directories() and interface libraries.