### PR TITLE
Fixes #82 - Intel 18 memory leak workaround.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,16 +34,6 @@ matrix:
                  - cmake
         env:
            - FC='gfortran-9'
-      - os: linux
-        addons:
-           apt:
-              sources:
-                 - ubuntu-toolchain-r-test
-              packages:
-                 - gfortran-9
-                 - cmake
-        env:
-           - FC='gfortran-9'
       - os: osx
         osx_image: xcode9.3
         env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,37 @@ matrix:
                  - cmake
         env:
            - FC='gfortran-9'
+      - os: linux
+        addons:
+           apt:
+              sources:
+                 - ubuntu-toolchain-r-test
+              packages:
+                 - gfortran-9
+                 - cmake
+        env:
+           - FC='gfortran-9'
       - os: osx
-        env: FC='gfortran-7' BREW='gcc@7' BREW_UP='cmake'
+        osx_image: xcode9.3
+        env:
+           - FC='gfortran-7'
+           - BREW='gcc@7'
+           - BREW_UP='cmake'
+           - CACHE_NAME=osx-gcc7
       - os: osx
-        env: FC='gfortran-8' BREW='gcc@8' BREW_UP='cmake'
+        osx_image: xcode9.3
+        env:
+           - FC='gfortran-8'
+           - BREW='gcc@8'
+           - BREW_UP='cmake'
+           - CACHE_NAME=osx-gcc8
       - os: osx
-        env: FC='gfortran-9' BREW='gcc@9' BREW_UP='cmake'
+        osx_image: xcode9.3
+        env:
+           - FC='gfortran-9'
+           - BREW='gcc@9'
+           - BREW_UP='cmake'
+           - CACHE_NAME=osx-gcc8
 
 before_install:
    - |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ project (GFTL
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set (CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/installed" CACHE PATH "..." FORCE)
-  message("Setting default install prefix to ${CMAKE_INSTALL_PREFIX}.")
-  message("Override with -DCMAKE_INSTALL_PREFIX=<path>.")
+  message("-- Setting default install prefix to ${CMAKE_INSTALL_PREFIX}.")
+  message("   Override with -DCMAKE_INSTALL_PREFIX=<path>.")
 endif ()
 
 
@@ -19,6 +19,7 @@ add_subdirectory (examples)
 
 find_package (PFUNIT 4.0.1 QUIET)
 if (PFUNIT_FOUND)
+  message("-- Detecting pFUnit: ${PFUNIT_DIR}")
   project (GFTL-TEST
     VERSION ${GFTL_VERSION}
     LANGUAGES Fortran

--- a/include/templates/map.inc
+++ b/include/templates/map.inc
@@ -153,7 +153,11 @@
 
 #include "templates/type_set_use_tokens.inc"
 
-#define __USE_ASSIGN(dest,src) dest=src
+#ifdef  __PAIR_ASSIGN
+#  define __USE_ASSIGN(dest,src) __PAIR_ASSIGN(dest,src)
+#else
+#  define __USE_ASSIGN(dest,src) __KEY_ASSIGN(dest%key,src%key); __VALUE_ASSIGN(dest%value,src%value)
+#endif
 #define __USE_MOVE(dest,src)  __KEY_MOVE(dest%key,src%key); __VALUE_MOVE(dest%value,src%value)
 #define __USE_FREE(x)
 

--- a/tests/Vector/CMakeLists.txt
+++ b/tests/Vector/CMakeLists.txt
@@ -54,7 +54,7 @@ foreach (type ${types} )
     DEPENDS ${infile}
     )
 
-  list (APPEND SRCS ${CMAKE_CURRENT_BINARY_DIR}/${pfunitfile} )
+  list (APPEND SRCS ${bin}/${pfunitfile} )
 
   set (infile ${src}/Test_VectorIterator.m4)
   set (pfunitfile Test_${type}VectorIterator.pf)
@@ -66,7 +66,7 @@ foreach (type ${types} )
     DEPENDS ${infile}
     )
 
-  list (APPEND SRCS ${CMAKE_CURRENT_BINARY_DIR}/${pfunitfile} )
+  list (APPEND SRCS ${bin}/${pfunitfile} )
 
 endforeach ()
 
@@ -78,7 +78,6 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
     endif()
   endif()
 endif()
-
 
 add_pfunit_ctest (vector_tests
   TEST_SOURCES ${SRCS}


### PR DESCRIPTION
Intel 18 produces correct results, but does has a memory leak
associated with assignment of variables of derived type with deferred
length string components.

Making the workaround the default, but may reverse that if other
problems are detected downstream.   I have provided a new CPP token

__PAIR_ASSIGN(dest,src)

That can override this behavior.