### PR TITLE
Fixes #86 - double allocate in workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if (COMMAND cmake_policy)
 endif (COMMAND cmake_policy)
 
 project (GFTL
-  VERSION 1.2.1
+  VERSION 1.2.2
   LANGUAGES NONE)
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -35,7 +35,7 @@ if (PFUNIT_FOUND)
     add_custom_target(tests COMMAND ${CMAKE_CTEST_COMMAND})
   endif ()
   
-  add_subdirectory(tests)
+  add_subdirectory(tests EXCLUDE_FROM_ALL)
 endif ()
 
 configure_file(GFTLConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/GFTLConfig.cmake @ONLY)

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -1,3 +1,7 @@
+1.2.2   2019-11-15
+	- bugfix for workaround in v1.2.1; some use cases were not
+	  deallocating structure components prior to reallocation.
+	
 1.2.1	2019-11-07
 	- added workaround for memory leak detected with Intel 18 compiler
 

--- a/cmake_utils/Intel.cmake
+++ b/cmake_utils/Intel.cmake
@@ -14,7 +14,7 @@ set(traceback "-traceback")
 set(cpp "-cpp")
 
 
-set(CMAKE_Fortran_FLAGS_DEBUG  "${no_optimize}")
+set(CMAKE_Fortran_FLAGS_DEBUG  "${no_optimize} ${check_all} ${traceback} -save-temps")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 set(CMAKE_Fortran_FLAGS "-g ${cpp} ${traceback} ${check_all} ${disable_warning_for_long_names} -save-temps")
 

--- a/include/templates/map.inc
+++ b/include/templates/map.inc
@@ -156,10 +156,19 @@
 #ifdef  __PAIR_ASSIGN
 #  define __USE_ASSIGN(dest,src) __PAIR_ASSIGN(dest,src)
 #else
-#  define __USE_ASSIGN(dest,src) __KEY_ASSIGN(dest%key,src%key); __VALUE_ASSIGN(dest%value,src%value)
+#  define __USE_ASSIGN(dest,src) __KEY_ASSIGN(dest%key,src%key);__VALUE_ASSIGN(dest%value,src%value)
 #endif
-#define __USE_MOVE(dest,src)  __KEY_MOVE(dest%key,src%key); __VALUE_MOVE(dest%value,src%value)
-#define __USE_FREE(x)
+
+#define __USE_MOVE(dest,src)  __KEY_MOVE(dest%key,src%key);__VALUE_MOVE(dest%value,src%value)
+
+#ifdef __PAIR_FREE
+#  define __USE_FREE(x) __PAIR_FREE(x)
+#else
+! FREE can be an empty string, but Fortran does not allow a bare ";".
+! The kludge is to put in a conditional that is always true.
+#  define __USE_FREE(x) if(.true.)then;__KEY_FREE(x%key); __VALUE_FREE(x%value);endif
+!#  define __USE_FREE(x)
+#endif
 
 #ifdef _alt
 ! vector<_type>

--- a/tests/Map/Test_map_double_assign.pf
+++ b/tests/Map/Test_map_double_assign.pf
@@ -92,4 +92,20 @@ contains
    end subroutine test_unlimited
 #endif
 
+
+   ! Reproducer for bug introduced in 1.2.1
+   ! Issue #86
+   @test
+   subroutine test_set_twice()
+     use Foo_mod
+     use integerFooPolyaltMap_mod
+
+      type (Map), target :: m
+      class (Foo), pointer :: p1, p2
+
+      call m%insert(1, Foo(1))
+      call m%set(1, Foo(2))  ! set() must first deallocate
+
+    end subroutine test_set_twice
+
 end module Test_map_double_assign


### PR DESCRIPTION
Previous release had a workaround for a memory leak in GFortran.
However for certain narrow use cases this workaround resulted in
code that attempted to reallocate an already allocated entity.

The situation is when a vector (and by implication altSet and altMap)
has an allocatable type, the set() method would allocate without
deallocating.  Use cases that simply grow and use containers without
updating existing entries were not affected.