### PR TITLE
Fixes #96 - Eliminate extraneous includes.

### DIFF
--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -2,9 +2,17 @@
 
 ## Unreleased
 
+### Deleted
+- Eliminated some types in the includes directory: Foo, FooPtr,
+  FooPoly, ...  These were used in early development of gFTL, but are
+  now duplicated in the tests/include.  Users should not see these -
+  only tests.
+  
+
+
 ### Fixed
- - eliminated stray <tab> in source code; was generating annoying
-   warnings in some compilers
+- eliminated stray <tab> in source code; was generating annoying
+  warnings in some compilers
 	
 ## [1.2.4] -  2019-12-19
 - fixes for CMakeList

--- a/tests/include/type_test_values/CMakeLists.txt
+++ b/tests/include/type_test_values/CMakeLists.txt
@@ -23,12 +23,6 @@ set (macro_files
   integerPtr
   integer2dPtr
   integerAlloc
-
-  Foo
-  FooPtr
-  FooPoly
-  FooPolyPtr
-
   )
 
 # Empty list - will append in loop below


### PR DESCRIPTION
Eliminated Foo* types in include/types directory.

These were originally introuced during development for testing, but
were eventually replaced by analogous types in the tests subdirectory.
The ones in the top include dir are unused and thus deleted.

...