### PR TITLE
Fixes #96 - do not install *Foo*.inc

### DIFF
--- a/include/types/CMakeLists.txt
+++ b/include/types/CMakeLists.txt
@@ -66,5 +66,6 @@ set_source_files_properties (${generated_incs} PROPERTIES GENERATED TRUE)
 install (DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ DESTINATION "${dest}/include/types"
   FILES_MATCHING PATTERN "*.inc"
   PATTERN CMakeFiles EXCLUDE
+  PATTERN "*Foo*" EXCLUDE
   )
 


### PR DESCRIPTION
These are only used for testing.