### PR TITLE
Use gnu m4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   message("   Override with -DCMAKE_INSTALL_PREFIX=<path>.")
 endif ()
 
+# For BSD systems use GNU m4
+find_program( M4 NAMES "gm4" "m4")
+if( NOT M4 )
+  message( SEND_ERROR "m4 program not found" )
+endif()
 
 add_subdirectory (include)
 add_subdirectory (examples)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Contributions of additional containers are very much welcomed.
 # Prerequisites
 
 * CMake 3.0
-* m4 (must be in path)
+* GNU m4 (must be in path as "gm4" or "m4")
 
 # Related package
 

--- a/include/templates/CMakeLists.txt
+++ b/include/templates/CMakeLists.txt
@@ -17,11 +17,6 @@ set (macro_files
 # Empty list - will append in loop below
 set(generated_incs)
 
-find_program( m4_found "m4" )
-if( NOT m4_found )
-  message( SEND_ERROR "m4 program not found" )
-endif()
-
 foreach( macro_file ${macro_files} )
   foreach( param ${template_params} )
     set( infile ${src}/${macro_file}.m4 )
@@ -30,7 +25,7 @@ foreach( macro_file ${macro_files} )
 
     add_custom_command (
       OUTPUT ${outfile}
-      COMMAND m4 -s -Dparam=${param} -I${src}/../templates < ${infile} > ${outfile}
+      COMMAND ${M4} -s -Dparam=${param} -I${src}/../templates < ${infile} > ${outfile}
       WORKING_DIRECTORY ${bin}
       DEPENDS ${infile}
       )

--- a/include/types/CMakeLists.txt
+++ b/include/types/CMakeLists.txt
@@ -46,7 +46,7 @@ foreach (macro_file ${macro_files})
 
     add_custom_command (
       OUTPUT ${outfile}
-      COMMAND m4 -s -Dparam=${param} -I${src}/../templates < ${infile} > ${outfile}
+      COMMAND ${M4} -s -Dparam=${param} -I${src}/../templates < ${infile} > ${outfile}
       WORKING_DIRECTORY ${bin}
       DEPENDS ${infile}
       )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory (Map)
 add_subdirectory (Set)
 add_subdirectory (altSet)
 
-# Need to exapnd intrinsic template for various types with m4
+# Need to expand intrinsic template for various types with m4
 add_subdirectory(include) 
 
 

--- a/tests/Map/CMakeLists.txt
+++ b/tests/Map/CMakeLists.txt
@@ -55,7 +55,7 @@ foreach (instantiation ${instantiations})
 
   add_custom_command (
     OUTPUT ${pfunitfile}
-    COMMAND m4 -s -DKEY=${key} -DVALUE=${value} -DALT= -Dformat=${format} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
+    COMMAND ${M4} -s -DKEY=${key} -DVALUE=${value} -DALT= -Dformat=${format} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
     WORKING_DIRECTORY ${bin}
     DEPENDS ${infile}
     )
@@ -70,7 +70,7 @@ foreach (instantiation ${instantiations})
 
   add_custom_command (
     OUTPUT ${pfunitfile}
-    COMMAND m4 -s -DKEY=${key} -DVALUE=${value} -DALT=alt -Dformat=${format} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
+    COMMAND ${M4} -s -DKEY=${key} -DVALUE=${value} -DALT=alt -Dformat=${format} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
     WORKING_DIRECTORY ${bin}
     DEPENDS ${infile}
     )

--- a/tests/Map/SUT/CMakeLists.txt
+++ b/tests/Map/SUT/CMakeLists.txt
@@ -51,7 +51,7 @@ foreach (instantiation ${instantiations})
 
   add_custom_command (
     OUTPUT ${outfile}
-    COMMAND m4 -s -Dkey=${key} -DALT -Dvalue=${value} -Dformat=${format} < ${infile} > ${outfile}
+    COMMAND ${M4} -s -Dkey=${key} -DALT -Dvalue=${value} -Dformat=${format} < ${infile} > ${outfile}
     WORKING_DIRECTORY ${bin}
     DEPENDS ${infile}
     )
@@ -66,7 +66,7 @@ list (APPEND SRCS ${outfile} )
 
   add_custom_command (
     OUTPUT ${outfile}
-    COMMAND m4 -s -Dkey=${key} -DALT=alt -Dvalue=${value} -Dformat=${format} < ${infile} > ${outfile}
+    COMMAND ${M4} -s -Dkey=${key} -DALT=alt -Dvalue=${value} -Dformat=${format} < ${infile} > ${outfile}
     WORKING_DIRECTORY ${bin}
     DEPENDS ${infile}
     )

--- a/tests/Set/CMakeLists.txt
+++ b/tests/Set/CMakeLists.txt
@@ -45,7 +45,7 @@ foreach (type ${types} )
 
   add_custom_command (
     OUTPUT ${pfunitfile}
-    COMMAND m4 -s -Dparam=${type} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
+    COMMAND ${M4} -s -Dparam=${type} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
     WORKING_DIRECTORY ${bin}
     DEPENDS ${infile}
     )

--- a/tests/Set/SUT/CMakeLists.txt
+++ b/tests/Set/SUT/CMakeLists.txt
@@ -55,7 +55,7 @@ foreach (instantiation ${instantiations})
   add_custom_command (
     OUTPUT ${outfile}
     DEPENDS ${infile}
-    COMMAND m4 -Dtype=${type} -Dformat=${format} ${infile} > ${outfile}
+    COMMAND ${M4} -Dtype=${type} -Dformat=${format} ${infile} > ${outfile}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
 

--- a/tests/Vector/CMakeLists.txt
+++ b/tests/Vector/CMakeLists.txt
@@ -49,7 +49,7 @@ foreach (type ${types} )
 
   add_custom_command (
     OUTPUT ${pfunitfile}
-    COMMAND m4 -s -Dparam=${type} -Dcompiler=${CMAKE_Fortran_COMPILER_ID} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
+    COMMAND ${M4} -s -Dparam=${type} -Dcompiler=${CMAKE_Fortran_COMPILER_ID} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
     WORKING_DIRECTORY ${bin}
     DEPENDS ${infile}
     )
@@ -61,7 +61,7 @@ foreach (type ${types} )
 
   add_custom_command (
     OUTPUT ${pfunitfile}
-    COMMAND m4 -s -Dparam=${type} -Dcompiler=${CMAKE_Fortran_COMPILER_ID} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
+    COMMAND ${M4} -s -Dparam=${type} -Dcompiler=${CMAKE_Fortran_COMPILER_ID} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
     WORKING_DIRECTORY ${bin}
     DEPENDS ${infile}
     )

--- a/tests/Vector/SUT/CMakeLists.txt
+++ b/tests/Vector/SUT/CMakeLists.txt
@@ -54,7 +54,7 @@ foreach (instantiation ${instantiations})
 
   add_custom_command (
     OUTPUT ${outfile}
-    COMMAND m4 -s -Dtype=${type} -Dformat=${format} < ${infile} > ${outfile}
+    COMMAND ${M4} -s -Dtype=${type} -Dformat=${format} < ${infile} > ${outfile}
     WORKING_DIRECTORY ${bin}
     DEPENDS ${infile}
     )

--- a/tests/altSet/CMakeLists.txt
+++ b/tests/altSet/CMakeLists.txt
@@ -41,7 +41,7 @@ foreach (type ${types} )
 
   add_custom_command (
     OUTPUT ${pfunitfile}
-    COMMAND m4 -s -Dparam=${type} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
+    COMMAND ${M4} -s -Dparam=${type} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${pfunitfile}
     WORKING_DIRECTORY ${bin}
     DEPENDS ${infile}
     )

--- a/tests/altSet/SUT/CMakeLists.txt
+++ b/tests/altSet/SUT/CMakeLists.txt
@@ -56,7 +56,7 @@ foreach (instantiation ${instantiations})
   add_custom_command (
     OUTPUT ${outfile}
     DEPENDS ${infile}
-    COMMAND m4 -Dtype=${type} -Dformat=${format} ${infile} > ${outfile}
+    COMMAND ${M4} -Dtype=${type} -Dformat=${format} ${infile} > ${outfile}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
 

--- a/tests/include/type_test_values/CMakeLists.txt
+++ b/tests/include/type_test_values/CMakeLists.txt
@@ -48,7 +48,7 @@ foreach( macro_file ${macro_files} )
 
     add_custom_command(
 	OUTPUT ${outfile}
-	COMMAND m4 -s -Dparam=${param} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${outfile}
+	COMMAND ${M4} -s -Dparam=${param} -I${GFTL_SOURCE_DIR}/include/templates < ${infile} > ${outfile}
 	WORKING_DIRECTORY ${bin}
 	DEPENDS ${infile}
 	)


### PR DESCRIPTION
BSD `m4` behaves differently from GNU version; most notably `PARAM()` is not uppercased, resulting in generation of `__type_MOVE` & co. instead of `__TYPE_MOVE`.

The suggested patch detects `m4` (preferring `gm4` to `m4`, if found) instead of using hardcoded one.

This fixes, for example, compilation of pFUnit on FreeBSD.