### PR TITLE
Update gFTL travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,113 +1,86 @@
-sudo: false
-dist: xenial
+os:
+   - linux
+   - osx
+
+dist: bionic
+
+osx_image: xcode11.6
+
 language: c
 
-matrix:
-   include:
-      - os: linux
-        addons:
-           apt:
-              sources:
-                 - ubuntu-toolchain-r-test
-              packages:
-                 - gfortran-8
-                 - cmake
-        env:
-           - FC='gfortran-8'
-      - os: linux
-        addons:
-           apt:
-              sources:
-                 - ubuntu-toolchain-r-test
-              packages:
-                 - gfortran-9
-                 - cmake
-        env:
-           - FC='gfortran-9'
-      - os: osx
-        osx_image: xcode9.3
-        addons:
-           homebrew:
-              packages:
-                 - gcc@8
-                 - cmake
-              update: true
-        env:
-           - FC='gfortran-8'
-           - CACHE_NAME=osx-gcc8
-      - os: osx
-        osx_image: xcode9.3
-        addons:
-           homebrew:
-              packages:
-                 - gcc@9
-                 - cmake
-              update: true
-        env:
-           - FC='gfortran-9'
-           - CACHE_NAME=osx-gcc9
+arch:
+  - amd64
 
-#before_install:
-#   - |
-#      if [ $TRAVIS_OS_NAME == osx ] ; then
-#         brew install ${BREW} make || exit 1
-#         brew upgrade ${BREW_UP} || exit 1
-#      fi
+addons:
+   apt:
+      sources:
+         - ubuntu-toolchain-r-test
+         - sourceline: deb https://apt.kitware.com/ubuntu/ bionic main
+           key_url: https://apt.kitware.com/keys/kitware-archive-latest.asc
+      packages:
+         - gfortran-9
+         - gfortran-10
+         - g++-9
+         - g++-10
+         - libgfortran5-dbg
+         - libxml2-utils
+         - cmake
+   homebrew:
+      packages:
+         - gcc@9
+         - cmake
+      update: false
 
-install:
-  # Set the ${CXX} variable properly
-#  - export CXX=${COMPILER}
-#  - ${CXX} --version
+env:
+   jobs:
+      - FC='gfortran-9' CC='gcc-9' CXX='g++-9'  CACHE_NAME=$TRAVIS_OS_NAME-$TRAVIS_CPU_ARCH-$FC
+      - FC='gfortran-10' CC='gcc-10' CXX='g++-10' CACHE_NAME=$TRAVIS_OS_NAME-$TRAVIS_CPU_ARCH-$FC
 
-  # Dependencies required by the CI are installed in ${TRAVIS_BUILD_DIR}/deps/
-  - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
-  - mkdir -p "${DEPS_DIR}"
-  - cd "${DEPS_DIR}"
-
-  # Travis machines have 2 cores
-  - JOBS=2
-
-  ############################################################################
-  # Install a recent CMake (unless already installed on OS X)
-  ############################################################################
-  - CMAKE_VERSION=3.14.5
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      CMAKE_URL="https://cmake.org/files/v${CMAKE_VERSION%.[0-9]}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
-      mkdir cmake && travis_retry wget --no-check-certificate -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
-      export PATH=${DEPS_DIR}/cmake/bin:${PATH}
-    else
-      brew install cmake || brew upgrade cmake
-    fi
-  - cmake --version
+# caching of the whole `local` directory. Can't cache only the one for this
+# `env`, because otherwise the different instances will overwrite the cache.
+# For the first test-run, the build has to be run sequentially (limit parallel
+# workers to 1) so that the cache can be correctly initialized. Once the cache
+# is build, parallel workers can be re-enabled.
+cache:
+   directories:
+      - ${HOME}/local
+   timeout: 600
 
 before_script:
-   # First get pFUnit
-   - cd ${HOME}
-   - git clone https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
-
-   # Now build pFUnit
-   - cd ${HOME}/pFUnit
-   - mkdir build-serial
-   - cd build-serial
-   - cmake .. -DCMAKE_Fortran_COMPILER=${FC} -DCMAKE_INSTALL_PREFIX=$HOME/Software/pFUnit -DSKIP_MPI=YES -DSKIP_OPENMP=YES
-   - make -j4 install
-
+   # Install cmake on linux (assume osx is good)
+   - |
+      if [ $TRAVIS_OS_NAME != 'osx' ] ; then
+         export cmake_ver=3.18.1
+         sh ./tools/travis-install-cmake.sh ${cmake_ver}
+         # set up cmake location
+         export PATH=${HOME}/local/cmake/bin:${PATH}
+         export LIBRARY_PATH=${HOME}/local/cmake/lib:${LIBRARY_PATH}
+         export LD_LIBRARY_PATH=${HOME}/local/cmake/lib:${LD_LIBRARY_PATH}
+         # print out version information
+         sudo apt purge --autoremove cmake
+         cmake --version
+      else
+         cmake --version
+      fi
+   # Install GFE dependencies
+   - |
+      ${FC} --version
+      bash ./tools/travis-install-gfe.bash
    # Now build gFTL
    - cd ${TRAVIS_BUILD_DIR}
-   - mkdir build
-   - cd build
-   - cmake .. -DCMAKE_Fortran_COMPILER=${FC} -DCMAKE_INSTALL_PREFIX=$HOME/Software/gFTL -DCMAKE_PREFIX_PATH=$HOME/Software/pFUnit -DCMAKE_BUILD_TYPE=Debug
+   - mkdir -p build && cd build
+   - cmake .. -DCMAKE_Fortran_COMPILER=${FC} -DCMAKE_INSTALL_PREFIX=${HOME}/Software/gFTL -DCMAKE_PREFIX_PATH=${HOME}/Software/GFE
 
 script:
-   # Build and install
-   - make -j 1 install
-   # Test
-   - make -j 1 tests
+   # Build
+   - make -j$(nproc) VERBOSE=1
+   # Make tests
+   - make -j$(nproc) tests
+   # Run tests
+   - ctest -j $(nproc) --output-on-failure
 
 notifications:
    email:
       recipients:
          - matthew.thompson@nasa.gov
-         - thomas.l.clune@nasa.gov
-         
+         - tom.clune@nasa.gov

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,4 @@
+# pFlogger/tools
+
+pFlogger/tools contains resources for use during development, build, and install, but which should not themselves be installed.
+

--- a/tools/travis-install-cmake.sh
+++ b/tools/travis-install-cmake.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+cmake_ver="$1"
+
+if [ ! -d "${HOME}/local/cmake/bin" ] ; then
+   wget https://github.com/Kitware/CMake/releases/download/v${cmake_ver}/cmake-${cmake_ver}.tar.gz
+   tar -xzf cmake-${cmake_ver}.tar.gz && rm cmake-${cmake_ver}.tar.gz
+   cd cmake-${cmake_ver}
+   mkdir build && cd build
+   cmake .. -DCMAKE_INSTALL_PREFIX=${HOME}/local/cmake
+   make -j$(nproc)
+   make install/strip
+   cd ../.. && rm -r cmake-${cmake_ver}
+fi

--- a/tools/travis-install-gfe.bash
+++ b/tools/travis-install-gfe.bash
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+GFE_DIR=${HOME}/gfe
+mkdir -p ${GFE_DIR}
+
+# First install prerequisites
+GFE_INSTALL_DIR=${HOME}/Software/GFE
+mkdir -p ${GFE_INSTALL_DIR}
+
+to_build=(pFUnit)
+for repo in "${to_build[@]}"
+do
+   cd ${GFE_DIR}
+   git clone https://github.com/Goddard-Fortran-Ecosystem/${repo}.git
+   cd ${GFE_DIR}/${repo}
+   mkdir build && cd build
+   cmake .. -DCMAKE_INSTALL_PREFIX=${GFE_INSTALL_DIR} -DCMAKE_PREFIX_PATH=${GFE_INSTALL_DIR}
+   make -j$(nproc) install
+done
+


### PR DESCRIPTION
This commit updates the gFTL Travis CI to use Ubuntu 18 and recent macOS. The macOS is recent in order to avoid a *very* expensive `brew update` call.