### PR TITLE
Workarounds for older compilers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if (COMMAND cmake_policy)
 endif (COMMAND cmake_policy)
 
 project (GFTL
-  VERSION 1.2.5
+  VERSION 1.2.6
   LANGUAGES Fortran)
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -2,9 +2,15 @@
 
 ## Unreleased
 
+## [1.2.6] - 2020-08-24
+
+
 ### Fixed
 - Blocked installation of *Foo*.inc include files that are
   only used for testing.
+
+- Reintroduced workarounds for older ifort and gfortran compilers.
+  Annoyingly the workaround for one breaks the other.
   
 ## [1.2.5] - 2020-04-06
 

--- a/include/templates/altSet_decl.inc
+++ b/include/templates/altSet_decl.inc
@@ -38,6 +38,9 @@
         procedure :: end => __PROC(end)
         procedure :: dump => __PROC(dump)
         procedure :: deepCopy => __PROC(deepCopy)
+#ifdef __GFORTRAN__
+        generic :: assignment(=) => deepCopy
+#endif
         procedure :: equalSets
         generic :: operator(==) => equalSets
         procedure :: notEqualSets


### PR DESCRIPTION
Some compilers need an explicit `assignment(=)` for deep copy of
containers.  Others break if you do that.   `#ifdef` to the rescue.