### PR TITLE
CMake: Add namespaced ALIAS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,11 @@ if (PFUNIT_FOUND)
   add_subdirectory(tests EXCLUDE_FROM_ALL)
 endif ()
 
+# The following is needed for external projects using *nix make when
+# parent project builds gFTL as a subproject.
+set (top_dir "GFTL-${GFTL_VERSION_MAJOR}.${GFTL_VERSION_MINOR}")
+set (GFTL_TOP_DIR "${CMAKE_INSTALL_PREFIX}/${top_dir}" CACHE PATH "")
+
 include(CMakePackageConfigHelpers)
 configure_package_config_file(GFTLConfig.cmake.in GFTLConfig.cmake
   INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/GFTLConfig.cmake
@@ -52,15 +57,11 @@ write_basic_package_version_file(GFTLConfig-version.cmake
   COMPATIBILITY SameMajorVersion
   )
 
-set (top_dir "GFTL-${GFTL_VERSION_MAJOR}.${GFTL_VERSION_MINOR}")
 install (
   FILES ${CMAKE_CURRENT_BINARY_DIR}/GFTLConfig.cmake ${CMAKE_CURRENT_BINARY_DIR}/GFTLConfig-version.cmake
   DESTINATION "${top_dir}/cmake"
   )
 
-# The following is needed for external projects using *nix make when
-# parent project builds gFTL as a subproject.
-set (GFTL_TOP_DIR "${CMAKE_INSTALL_PREFIX}/${top_dir}" CACHE PATH "")
 configure_file(GFTL.mk.in ${CMAKE_CURRENT_BINARY_DIR}/GFTL.mk @ONLY)
 install (
   FILES ${CMAKE_CURRENT_BINARY_DIR}/GFTL.mk 

--- a/GFTLConfig.cmake.in
+++ b/GFTLConfig.cmake.in
@@ -2,4 +2,5 @@
 
 @PACKAGE_INIT@
 
+set (GFTL_TOP_DIR "@GFTL_TOP_DIR@")
 include ("${CMAKE_CURRENT_LIST_DIR}/GFTLTargets.cmake")

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_library (gftl INTERFACE)
+add_library (GFTL::gftl ALIAS gftl)
+
 set (dest "GFTL-${GFTL_VERSION_MAJOR}.${GFTL_VERSION_MINOR}")
 target_include_directories (gftl INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> # for headers when building

--- a/tests/shared/CMakeLists.txt
+++ b/tests/shared/CMakeLists.txt
@@ -5,7 +5,5 @@ set (SRCS
 )
 
 add_library(shared ${SRCS})
-target_include_directories (shared PRIVATE ${PFUNIT_TOP_DIR}/include)
 target_include_directories (shared PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(shared gftl funit)
-
+target_link_libraries(shared GFTL::gftl PFUNIT::funit)

--- a/tools/travis-install-gfe.bash
+++ b/tools/travis-install-gfe.bash
@@ -15,6 +15,8 @@ do
    cd ${GFE_DIR}
    git clone https://github.com/Goddard-Fortran-Ecosystem/${repo}.git
    cd ${GFE_DIR}/${repo}
+   # Necessary for consistent CMake targets
+   git checkout cmake-fixes
    mkdir build && cd build
    cmake .. -DCMAKE_INSTALL_PREFIX=${GFE_INSTALL_DIR} -DCMAKE_PREFIX_PATH=${GFE_INSTALL_DIR}
    make -j$(nproc) install


### PR DESCRIPTION
Allows more consistent treatment of library across different use cases (external installation, build directory, git submodule)