### PR TITLE
Modifications to intel compiler flags when compiling on Windows with Intel compiler

### DIFF
--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixed
-
+- Added support for compiling on Windows with Intel compiler.
 - Corrected uninitialized value problem with v2 maps.  Detected
   by NAG with aggressive debug flags.
 - Corrected logic for default value for vectors of (polymorphic)

--- a/cmake/Intel.cmake
+++ b/cmake/Intel.cmake
@@ -2,20 +2,26 @@
 
 if(WIN32)
   set(no_optimize "-Od")
-  set(check_all "-check:all")
+  set(check_all "-check:all)
+  set(debug_info "-Zi")
+  set(save_temps "-Qsave-temps")
+  set(disable_warning_for_long_names "-Qdiag-disable:5462")
+  set(cpp "-fpp")
 else()
   set(no_optimize "-O0")
   set(check_all "-check all,noarg_temp_created")
+  set(debug_info "-g")
+  set(save_temps "-save-temps")
+  set(disable_warning_for_long_names "-diag-disable 5462")
+  set(cpp "-cpp")
 endif()
   
 
-set(disable_warning_for_long_names "-diag-disable 5462")
 set(traceback "-traceback")
-set(cpp "-cpp")
 
 
-set(CMAKE_Fortran_FLAGS_DEBUG  "${no_optimize} ${check_all} ${traceback} -save-temps")
+set(CMAKE_Fortran_FLAGS_DEBUG  "${no_optimize} ${check_all} ${traceback} ${save_temps}")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
-set(CMAKE_Fortran_FLAGS "-g ${cpp} ${traceback} ${check_all} ${disable_warning_for_long_names} -save-temps")
+set(CMAKE_Fortran_FLAGS "${debug_info} ${cpp} ${traceback} ${check_all} ${disable_warning_for_long_names} ${save_temps}")
 
 add_definitions(-D_INTEL)


### PR DESCRIPTION
The flags -g, -save-temps, -diag-disable 5462, and -cpp are different for the Windows version of the Intel Fortran compiler.