### PR TITLE
Feature/allocatable node 3rd attempt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-10.15, macos-11]
         compiler: [gfortran-8, gfortran-9, gfortran-10, gfortran-11]
+        exclude:
+          - os: macos-10.15
+            compiler: gfortran-8
 
       # fail-fast is set to 'true' here which is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-10.15, macos-11]
-        compiler: [gfortran-8, gfortran-9, gfortran-10, gfortran-11]
+        compiler: [gfortran-8, gfortran-9, gfortran-10]
         exclude:
           - os: macos-10.15
             compiler: gfortran-8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-10.15, macos-11]
         compiler: [gfortran-8, gfortran-9, gfortran-10, gfortran-11]
 
       # fail-fast is set to 'true' here which is good for production, but when
@@ -29,6 +29,14 @@ jobs:
 
     name: ${{ matrix.os }} / ${{ matrix.compiler }}
     steps:
+      - name: Install GCC 8 on Ubuntu 20
+        if: matrix.os == 'ubuntu-20.04' && matrix.compiler == 'gfortran-8'
+        run: |
+          sudo apt-get install gfortran-8 -y
+      - name: Install GCC 11 on Ubuntu 20
+        if: matrix.os == 'ubuntu-20.04' && matrix.compiler == 'gfortran-11'
+        run: |
+          sudo apt-get install gfortran-11 -y
       - name: Compiler Versions
         run: |
           ${FC} --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ jobs:
         exclude:
           - os: macos-10.15
             compiler: gfortran-8
+          - os: macos-11
+            compiler: gfortran-8
 
       # fail-fast is set to 'true' here which is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-10.15]
-        compiler: [gfortran-9, gfortran-10]
+        compiler: [gfortran-8, gfortran-9, gfortran-10, gfortran-11]
 
       # fail-fast is set to 'true' here which is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -17,6 +17,9 @@
   within expressions involving user defined `==` and `<`.   Some attempt was made to use
   `ASSOCIATE` instead, but NAG 7.0 had trouble with one of those.    A reproducer for
   the Intel problem has been created and will be submitted.
+- Set container now uses ALLOCATABLE for children rather than pointers.   This makes
+  some internal algorithms a bit painful to implement, but avoids the need for explicit
+  FINAL methods which appear to expose buggy compilers.  (Hard to isolate though.)
 
 
 ## [1.4.1] - 2021-04-09

--- a/include/v2/set/iterator_procedures.inc
+++ b/include/v2/set/iterator_procedures.inc
@@ -6,7 +6,7 @@
       __T_declare_result__, pointer :: value
 
       if (associated(this%node)) then
-         value  => this%node%value
+         value  => this%node%get_value()
       else
          value => null()
       end if

--- a/include/v2/set/iterator_specification.inc
+++ b/include/v2/set/iterator_specification.inc
@@ -3,7 +3,7 @@
    type :: __set_iterator
       private
       type(__set), pointer :: tree => null()
-      class(__base_node), pointer :: node => null()
+      type(__set_node), pointer :: node => null()
    contains
       procedure :: of => __MANGLE(iter_of)
       procedure :: next => __MANGLE(iter_next)

--- a/include/v2/set/iterator_specification.inc
+++ b/include/v2/set/iterator_specification.inc
@@ -3,7 +3,7 @@
    type :: __set_iterator
       private
       type(__set), pointer :: tree => null()
-      type(__MANGLE(node)), pointer :: node => null()
+      class(__base_node), pointer :: node => null()
    contains
       procedure :: of => __MANGLE(iter_of)
       procedure :: next => __MANGLE(iter_next)

--- a/include/v2/set/node_procedures.inc
+++ b/include/v2/set/node_procedures.inc
@@ -1,26 +1,75 @@
 
    ! =======================
-   !  child()
+   !  get_parent()
    ! =======================
-   function __MANGLE(child)(this, idx) result(child)
+   function __MANGLE(get_parent)(this) result(parent)
+      class(__set_node), intent(in) :: this
+      type(__set_node), pointer :: parent
+
+      parent => this%parent
+
+   end function __MANGLE(get_parent)
+
+
+   ! =======================
+   !  has_child()
+   ! =======================
+   logical function __MANGLE(has_child)(this, side)
+      class(__set_node), target, intent(in) :: this
+      integer :: side
+      type(__set_node), pointer :: child
+
+      if (side ==__LEFT) has_child = allocate(this%left)
+      if (side == __RIGHT) has_child = allocated(this%right)
+
+   end function __MANGLE(has_child)
+   
+   ! =======================
+   !  get_child()
+   ! =======================
+   function __MANGLE(get_child)(this, side) result(child)
       class(__set_node), target, intent(in) :: this
       integer :: idx
       type(__set_node), pointer :: child
 
-      if (idx==0) child=>this%left
-      if (idx==1) child=>this%right
+      if (side == __LEFT) then
+         select type (q => this%left)
+         type is (__set_node)
+            child => q
+         end select
+      if (side == __RIGHT) then
+         select type (q => this%right)
+         type is (__set_node)
+            child => q
+         end select
+      end if
 
-   end function __MANGLE(child)
+   end function __MANGLE(get_child)
+
+   ! =======================
+   !  which_side_am_i()
+   ! =======================
+   integer function which_side_am_i(this) result(side)
+      class(__set_node), target, intent(in) :: this
+
+      type(__set_node), pointer :: parent
+
+      parent => this%get_parent
+      if (.not. associated(parent)) error stop 'root node is neither left nor right'
+
+      side = parent%which_child(this)
+      
+   end function I_which_side_am_i
 
    ! =======================
    !  which_child()
    ! =======================
-   function __MANGLE(which_child)(this, child) result(which_child)
+   function __MANGLE(which_child)(this, child) result(side)
+      integer :: side
       class(__set_node), intent(in) :: this
       type(__set_node), target, intent(in) :: child
-      integer :: which_child
 
-      which_child = merge(__LEFT, __RIGHT, associated(this%left, target=child))
+      side = merge(__LEFT, __RIGHT, associated(this%left, target=child))
 
    end function __MANGLE(which_child)
 
@@ -46,19 +95,10 @@
 
       h0 = 0
       h1 = 0
-      if (associated(this%left)) h0 = this%left%height
-      if (associated(this%right)) h1 = this%right%height
+      if (allocated(this%left)) h0 = this%left%height
+      if (allocated(this%right)) h1 = this%right%height
       this%height = max(h0, h1) + 1
 
       return
    end subroutine __MANGLE(update_height)
 
-   
-   recursive subroutine __MANGLE(finalize_node)(this)
-      type(__set_node), intent(inout) :: this
-      
-      if (associated(this%left)) deallocate(this%left)
-      if (associated(this%right)) deallocate(this%right)
-
-      return
-   end subroutine __MANGLE(finalize_node)

--- a/include/v2/set/node_procedures.inc
+++ b/include/v2/set/node_procedures.inc
@@ -77,7 +77,7 @@
       case (__LEFT)
          call move_alloc(from=node, to=this%left)
       case (__RIGHT)
-         call move_allooc(from=node, to=this%right)
+         call move_alloc(from=node, to=this%right)
       end select
 
       return

--- a/include/v2/set/node_procedures.inc
+++ b/include/v2/set/node_procedures.inc
@@ -98,6 +98,24 @@
       
    end subroutine __MANGLE(set_child)
 
+   ! =======================
+   !  deallocate_child()
+   ! =======================
+   subroutine __MANGLE(deallocate_child)(this, side)
+      class(__set_node), intent(inout) :: this
+      integer, intent(in) :: side
+
+      select case (side)
+      case (__LEFT)
+         deallocate(this%left)
+      case (__RIGHT)
+         deallocate(this%right)
+      end select
+
+      return
+      
+   end subroutine __MANGLE(deallocate_child)
+
 
    ! =======================
    !  set_value()

--- a/include/v2/set/node_procedures.inc
+++ b/include/v2/set/node_procedures.inc
@@ -14,12 +14,11 @@
    ! =======================
    !  has_child()
    ! =======================
-   logical function __MANGLE(has_child)(this, side)
-      class(__set_node), target, intent(in) :: this
-      integer :: side
-      type(__set_node), pointer :: child
+   logical function __MANGLE(has_child)(this, side) result(has_child)
+      class(__set_node), intent(in) :: this
+      integer, intent(in) :: side
 
-      if (side ==__LEFT) has_child = allocate(this%left)
+      if (side ==__LEFT) has_child = allocated(this%left)
       if (side == __RIGHT) has_child = allocated(this%right)
 
    end function __MANGLE(has_child)
@@ -28,15 +27,18 @@
    !  get_child()
    ! =======================
    function __MANGLE(get_child)(this, side) result(child)
-      class(__set_node), target, intent(in) :: this
-      integer :: idx
       type(__set_node), pointer :: child
+      class(__set_node), target, intent(in) :: this
+      integer, intent(in) :: side
 
       if (side == __LEFT) then
          select type (q => this%left)
          type is (__set_node)
             child => q
          end select
+         return
+      end if
+
       if (side == __RIGHT) then
          select type (q => this%right)
          type is (__set_node)
@@ -49,17 +51,17 @@
    ! =======================
    !  which_side_am_i()
    ! =======================
-   integer function which_side_am_i(this) result(side)
+   integer function __MANGLE(which_side_am_i)(this) result(side)
       class(__set_node), target, intent(in) :: this
 
       type(__set_node), pointer :: parent
 
-      parent => this%get_parent
+      parent => this%get_parent()
       if (.not. associated(parent)) error stop 'root node is neither left nor right'
 
       side = parent%which_child(this)
       
-   end function I_which_side_am_i
+   end function __MANGLE(which_side_am_i)
 
    ! =======================
    !  which_child()
@@ -69,34 +71,54 @@
       class(__set_node), intent(in) :: this
       type(__set_node), target, intent(in) :: child
 
-      side = merge(__LEFT, __RIGHT, associated(this%left, target=child))
+      type(__set_node), pointer :: left
+
+      left => this%get_child(__LEFT)
+      if (associated(left)) then
+         if (associated(left, target=child)) then
+            side = __LEFT
+            return
+         end if
+      else
+         side = __RIGHT
+      end if
+      return
 
    end function __MANGLE(which_child)
 
    ! =======================
    !  set_child()
    ! =======================
-   subroutine __MANGLE(set_child)(this, idx, child)
+   subroutine __MANGLE(set_child)(this, side, child)
       class(__set_node), intent(inout) :: this
-      integer, intent(in) :: idx
+      integer, intent(in) :: side
       type(__set_node), pointer, intent(in) :: child
 
-      if (idx==__LEFT) this%left => child
-      if (idx==__RIGHT) this%right => child
+      if (side == __LEFT)  allocate(this%left, source=child)
+      if (side == __RIGHT) allocate(this%right, source=child)
       return
+      
    end subroutine __MANGLE(set_child)
+
+   ! =======================
+   !  get_height()
+   ! =======================
+   integer function __MANGLE(get_height)(this) result(height)
+      class(__set_node), intent(in) :: this
+      height = this%height
+   end function __MANGLE(get_height)
 
    ! =======================
    !  update_height()
    ! =======================
    subroutine __MANGLE(update_height)(this)
-      class(__set_node), target, intent(inout) :: this
+      class(__set_node), intent(inout) :: this
       integer :: h0, h1
 
       h0 = 0
       h1 = 0
-      if (allocated(this%left)) h0 = this%left%height
-      if (allocated(this%right)) h1 = this%right%height
+      if (allocated(this%left)) h0 = this%left%get_height()
+      if (allocated(this%right)) h1 = this%right%get_height()
       this%height = max(h0, h1) + 1
 
       return

--- a/include/v2/set/node_procedures.inc
+++ b/include/v2/set/node_procedures.inc
@@ -170,8 +170,11 @@
          if (associated(left, target=child)) then
             side = __LEFT
             return
+         else
+            side = __RIGHT
+            return
          end if
-      else
+      else ! must be at least one child when this procedure is called
          side = __RIGHT
       end if
       return

--- a/include/v2/set/node_procedures.inc
+++ b/include/v2/set/node_procedures.inc
@@ -1,3 +1,17 @@
+   ! =======================
+   !  to_node()
+   ! =======================
+   function __MANGLE(to_node)(this) result(node)
+      class(__set_node), target, intent(in) :: this
+      type(__set_node), pointer :: node
+
+      select type(this)
+      type is (__set_node)
+         node => this
+      end select
+
+   end function __MANGLE(to_node)
+
 
    ! =======================
    !  get_parent()

--- a/include/v2/set/node_procedures.inc
+++ b/include/v2/set/node_procedures.inc
@@ -12,6 +12,17 @@
 
 
    ! =======================
+   !  set_parent()
+   ! =======================
+   subroutine __MANGLE(set_parent)(this, parent)
+      class(__set_node), intent(inout) :: this
+      type(__set_node), pointer, intent(in) :: parent
+
+      this%parent => parent
+      
+   end subroutine __MANGLE(set_parent)
+
+   ! =======================
    !  has_child()
    ! =======================
    logical function __MANGLE(has_child)(this, side) result(has_child)
@@ -32,21 +43,70 @@
       integer, intent(in) :: side
 
       if (side == __LEFT) then
-         select type (q => this%left)
-         type is (__set_node)
-            child => q
-         end select
-         return
+         if (allocated(this%left)) then
+            select type (q => this%left)
+            type is (__set_node)
+               child => q
+            end select
+            return
+         end if
       end if
 
       if (side == __RIGHT) then
-         select type (q => this%right)
-         type is (__set_node)
-            child => q
-         end select
+         if (allocated(this%right)) then
+            select type (q => this%right)
+            type is (__set_node)
+               child => q
+            end select
+            return
+         end if
       end if
+      child => null()
 
    end function __MANGLE(get_child)
+
+   ! =======================
+   !  set_child()
+   ! =======================
+   subroutine __MANGLE(set_child)(this, side, node)
+      class(__set_node), intent(inout) :: this
+      integer, intent(in) :: side
+      type(__set_node), allocatable, intent(inout) :: node
+
+      select case (side)
+      case (__LEFT)
+         call move_alloc(from=node, to=this%left)
+      case (__RIGHT)
+         call move_allooc(from=node, to=this%right)
+      end select
+
+      return
+      
+   end subroutine __MANGLE(set_child)
+
+
+   ! =======================
+   !  set_value()
+   ! =======================
+   subroutine __MANGLE(set_value)(this, value)
+      class(__set_node), intent(inout) :: this
+      __T_declare_dummy__, intent(in) :: value
+
+      __T_COPY__(this%value, value)
+      return
+   end subroutine __MANGLE(set_value)
+
+   ! =======================
+   !  get_value()
+   ! =======================
+   function __MANGLE(get_value)(this) result(value)
+      __T_declare_result__, pointer :: value
+      class(__set_node), target, intent(in) :: this
+
+      value => this%value
+
+   end function __MANGLE(get_value)
+
 
    ! =======================
    !  which_side_am_i()
@@ -86,19 +146,6 @@
 
    end function __MANGLE(which_child)
 
-   ! =======================
-   !  set_child()
-   ! =======================
-   subroutine __MANGLE(set_child)(this, side, child)
-      class(__set_node), intent(inout) :: this
-      integer, intent(in) :: side
-      type(__set_node), pointer, intent(in) :: child
-
-      if (side == __LEFT)  allocate(this%left, source=child)
-      if (side == __RIGHT) allocate(this%right, source=child)
-      return
-      
-   end subroutine __MANGLE(set_child)
 
    ! =======================
    !  get_height()

--- a/include/v2/set/node_specification.inc
+++ b/include/v2/set/node_specification.inc
@@ -1,0 +1,133 @@
+   type, abstract :: __base_node
+   contains
+      procedure(I_to_node), deferred :: to_node
+      procedure(I_get_parent), deferred :: get_parent
+      procedure(I_set_parent), deferred :: set_parent
+      procedure(I_has_child), deferred :: has_child
+      procedure(I_get_child), deferred :: get_child
+      procedure(I_set_child), deferred :: set_child
+      procedure(I_deallocate_child), deferred :: deallocate_child
+      procedure(I_get_value), deferred :: get_value
+      procedure(I_set_value), deferred :: set_value
+      
+      procedure(I_which_side_am_i), deferred :: which_side_am_i
+      procedure(I_which_child), deferred :: which_child
+      procedure(I_get_height), deferred :: get_height
+      procedure(I_update_height), deferred :: update_height
+   end type __base_node
+
+   type, extends(__base_node) ::  __set_node
+      type(__set_node), pointer :: parent => null()
+      class(__base_node), allocatable :: left
+      class(__base_node), allocatable :: right
+      integer :: height=1
+      __T_declare_component__ :: value
+   contains
+      procedure :: to_node => __MANGLE(to_node)
+      procedure :: get_parent =>  __MANGLE(get_parent)
+      procedure :: set_parent =>  __MANGLE(set_parent)
+      procedure :: has_child => __MANGLE(has_child)
+      procedure :: get_child => __MANGLE(get_child)
+      procedure :: set_child => __MANGLE(set_child)
+      procedure :: deallocate_child => __MANGLE(deallocate_child)
+      procedure :: get_value => __MANGLE(get_value)
+      procedure :: set_value => __MANGLE(set_value)
+      
+      procedure :: which_child => __MANGLE(which_child)
+      procedure :: which_side_am_i => __MANGLE(which_side_am_i)
+
+      procedure :: get_height => __MANGLE(get_height)
+      procedure :: update_height => __MANGLE(update_height)
+   end type __set_node
+
+   abstract interface
+
+      function I_to_node(this) result(node)
+         import __base_node
+         import __set_node
+         type(__set_node), pointer :: node
+         class(__base_node), target, intent(in) :: this
+      end function I_to_node
+      
+      function I_get_parent(this) result(parent)
+         import __base_node
+         import __set_node
+         type(__set_node), pointer :: parent
+         class(__base_node), intent(in) :: this
+      end function I_get_parent
+
+      subroutine I_set_parent(this, parent)
+         import __base_node
+         import __set_node
+         class(__base_node), intent(inout) :: this
+         type(__set_node), pointer, intent(in) :: parent
+      end subroutine I_set_parent
+
+      logical function I_has_child(this, side) result(has_child)
+         import __base_node
+         class(__base_node), intent(in) :: this
+         integer, intent(in) :: side
+      end function I_has_child
+
+      function I_get_child(this, side) result(child)
+         import __base_node
+         import __set_node
+         type(__set_node), pointer :: child
+         class(__base_node), target, intent(in) :: this
+         integer, intent(in) :: side
+      end function I_get_child
+
+      subroutine I_set_child(this, side, node)
+         import __base_node
+         import __set_node
+         class(__base_node), intent(inout) :: this
+         integer, intent(in) :: side
+         type(__set_node), allocatable, intent(inout) :: node
+      end subroutine I_set_child
+
+      subroutine I_deallocate_child(this, side)
+         import __base_node
+         class(__base_node), intent(inout) :: this
+         integer, intent(in) :: side
+      end subroutine I_deallocate_child
+
+      function I_get_value(this) result(value)
+         import __base_node
+         import __set_node
+         __T_declare_result__, pointer :: value
+         class(__base_node), target, intent(in) :: this
+      end function I_get_value
+
+      subroutine I_set_value(this, value)
+         import __base_node
+         class(__base_node), intent(inout) :: this
+         __T_declare_dummy__, intent(in) :: value
+      end subroutine I_set_value
+
+      
+      integer function I_which_side_am_i(this) result(side)
+         import __base_node
+         class(__base_node), target, intent(in) :: this
+      end function I_which_side_am_i
+
+      integer function I_which_child(this, child) result(side)
+         import __base_node
+         import __set_node
+         class(__base_node), intent(in) :: this
+         type(__set_node), target, intent(in) :: child
+      end function I_which_child
+
+      integer function I_get_height(this) result(height)
+         import __base_node
+         class(__base_node), intent(in) :: this
+      end function I_get_height
+
+      subroutine I_update_height(this)
+         import __base_node
+         class(__base_node), intent(inout) :: this
+      end subroutine I_update_height
+
+   end interface
+
+
+      

--- a/include/v2/set/node_specification.inc
+++ b/include/v2/set/node_specification.inc
@@ -92,14 +92,13 @@
       end subroutine I_deallocate_child
 
       function I_get_value(this) result(value)
-         import __base_node
-         import __set_node
+         import ! have to import all to get __T as we don't know if it is intrinsic
          __T_declare_result__, pointer :: value
          class(__base_node), target, intent(in) :: this
       end function I_get_value
 
       subroutine I_set_value(this, value)
-         import __base_node
+         import ! have to import all to get __T as we don't know if it is intrinsic
          class(__base_node), intent(inout) :: this
          __T_declare_dummy__, intent(in) :: value
       end subroutine I_set_value

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -17,6 +17,7 @@
 #define __LEFT 0
 #define __RIGHT 1
 
+#define __base_node __MANGLE(BaseNode)
 #define __set_node __MANGLE(Node)
 
 #include "set/node_procedures.inc"
@@ -803,18 +804,6 @@
 
    end subroutine __MANGLE(copy_list)
 #endif
-   ! =======================
-   !  finalize_set()
-   ! =======================
-   recursive subroutine __MANGLE(finalize_set)(this)
-      type(__set), intent(inout) :: this
-
-      if (associated(this%root)) deallocate(this%root)
-
-      return
-   end subroutine __MANGLE(finalize_set)
-
-
    ! Suboptimal implementation
    subroutine __MANGLE(merge)(this, source)
       class(__set), intent(inout) :: this

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -156,9 +156,9 @@
       logical, optional, intent(out) :: is_new
       type(__set_iterator), optional, intent(out) :: iter
       type(__set_node), target, allocatable :: new
-      class(__base_node), pointer :: parent
+      type(__set_node), pointer :: parent
 
-      class(__base_node), pointer :: r
+      class(__set_node), pointer :: r
 
       call dump_at_line(this, __LINE__)
       if (present(iter)) iter%tree => this
@@ -193,8 +193,11 @@
          call this%rebalance(parent, .true.)
       else
          allocate(__set_node :: this%root)
-         if (present(iter)) iter%node => this%root
-         r => this%root
+         if (present(iter)) iter%node => this%root%to_node()
+         select type (q => this%root)
+         type is (__set_node)
+            r => q
+         end select
          call r%set_value(value)
 !!$         __T_COPY__(r%value, value)
          if (present(is_new)) then
@@ -370,7 +373,7 @@
       type(__set_iterator), intent(in) :: first
       type(__set_iterator), intent(in) :: last
       type(__set_node), pointer :: parent
-      class(__base_node), pointer :: pos
+      type(__set_node), pointer :: pos
 
       type (__set_iterator) :: iter
 
@@ -493,13 +496,13 @@
    !  find_node
    ! =======================
    function __MANGLE(find_node)(this, value, last) result(find_node)
-      class(__base_node), pointer :: find_node
+      type(__set_node), pointer :: find_node
       class(__set), target, intent(in) :: this
       __T_declare_dummy__, intent(in) :: value
       logical, intent(in) :: last
       integer :: side
 
-      find_node => this%root
+      find_node => this%root%to_node()
       if (associated(find_node)) then
          do
             if (.not. last .and. (                                           &
@@ -559,8 +562,7 @@
    ! =======================
    subroutine __MANGLE(erase_nonleaf)(this, pos, side)
       class(__set), intent(inout) :: this
-!!$      type(__set_node), pointer, intent(inout) :: pos
-      class(__base_node), pointer, intent(inout) :: pos
+      type(__set_node), pointer, intent(inout) :: pos
       integer, intent(in) :: side
       type(__set_node), pointer :: parent, other, child0, child1
       type(__set_node), pointer :: otherchild, otherparent
@@ -611,7 +613,7 @@
 
       if (.not.associated(pos)) then
          if (.not. allocated(this%root)) return
-         pos => this%root
+         pos => this%root%to_node()
          do while (associated(pos%get_child(1-dir)))
             pos => pos%get_child(1-dir)
          end do
@@ -934,7 +936,7 @@
       class(__set), target, intent(inout) :: this
       type(__set), target, intent(inout) :: x
 
-      class(__set_node), allocatable :: tmp
+      class(__base_node), allocatable :: tmp
       integer(kind=GFTL_SIZE_KIND) :: tsize
 
       call move_alloc(from=this%root, to=tmp)
@@ -957,7 +959,7 @@
       print*
       print*,'At line: ', line
       if (this%size() > 0) then
-         node => this%root
+         node => this%root%to_node()
          call dump(node)
       end if
    end subroutine dump_at_line

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -160,7 +160,6 @@
 
       class(__set_node), pointer :: r
 
-      call dump_at_line(this, __LINE__)
       if (present(iter)) iter%tree => this
 
       if (allocated(this%root)) then
@@ -199,13 +198,11 @@
             r => q
          end select
          call r%set_value(value)
-!!$         __T_COPY__(r%value, value)
          if (present(is_new)) then
             is_new = .true.
          end if
       endif
       this%tsize = this%tsize + 1
-      call dump_at_line(this, __LINE__)
       return
       if (present(unused)) print*,shape(unused)
 
@@ -388,16 +385,14 @@
          else if (pos%has_child(__LEFT)) then
             call this%erase_nonleaf(pos, __LEFT)
          else
+
             parent => pos%get_parent()
             if (associated(parent)) then
-               call parent%set_child(parent%which_child(pos), null())
+               call parent%deallocate_child(parent%which_child(pos))
                call this%rebalance(parent, .false.)
             else
-!!! TODO - will this come out in the wash?
-!!$               this%root => null()
                deallocate(this%root)
             endif
-            deallocate(pos)
          endif
          this%tsize=this%tsize-1
       end do
@@ -472,26 +467,6 @@
    end function __MANGLE(upper_bound)
 
 
-!!$   ! =======================
-!!$   !  write_formatted
-!!$   ! =======================
-!!$   recursive subroutine __MANGLE(write_formatted)(this, pos)
-!!$      class(__set), intent(in) :: this
-!!$      type(__set_node), pointer, intent(in), optional :: pos
-!!$
-!!$      if (present(pos)) then
-!!$         if (associated(pos%left)) call this%write_formatted(pos%left)
-!!$         write(*, *)pos%value, loc(pos), loc(pos%parent), loc(pos%left),  &
-!!$              &       loc(pos%right), pos%get_height()
-!!$         if (associated(pos%right)) call this%write_formatted(pos%right)
-!!$      else
-!!$         write(*, *)'size=',this%getsize()
-!!$         write(*, *)'root=',loc(this%root)
-!!$         call this%write_formatted(this%root)
-!!$      endif
-!!$      return
-!!$   end subroutine __MANGLE(write_formatted)
-!!$
    ! =======================
    !  find_node
    ! =======================
@@ -533,9 +508,7 @@
          hr=0
          if (curr%has_child(__LEFT)) hl=curr%left%get_height()
          if (curr%has_child(__RIGHT)) hr=curr%right%get_height()
-
          unbalanced=abs(hl-hr)>1
-         print*,__FILE__,__LINE__,'unbalanced? ', unbalanced, hl, hr
          if (unbalanced) then
             side = merge(__LEFT, __RIGHT, hl > hr)
             child => curr%get_child(side)
@@ -545,7 +518,6 @@
             if (child%has_child(__RIGHT)) chr = child%right%get_height()
             if (chr /= chl) then
                child_side=merge(__LEFT, __RIGHT, chl > chr)
-               print*,__FILE__,__LINE__, 'same side?',side, child_side
                if (side /= child_side) call this%rot(child, 1-child_side)
                call this%rot(curr, 1-side)
             endif
@@ -560,45 +532,78 @@
    ! =======================
    !  erase_nonleaf
    ! =======================
-   subroutine __MANGLE(erase_nonleaf)(this, pos, side)
+subroutine __MANGLE(erase_nonleaf)(this, pos, side)
       class(__set), intent(inout) :: this
       type(__set_node), pointer, intent(inout) :: pos
       integer, intent(in) :: side
       type(__set_node), pointer :: parent, other, child0, child1
       type(__set_node), pointer :: otherchild, otherparent
+      class(__base_node), allocatable :: tmp_other, tmp_pos
+      
+      parent => pos%parent
+      other => pos
+      call this%advpos(other, side)
+      child0 => pos%get_child(side)
+      child1 => pos%get_child(1-side)
+      otherchild => other%get_child(side)
+      otherparent => other%parent
 
-!!$      parent => pos%parent
-!!$      other => pos
-!!$      call this%advpos(other, side)
-!!$      child0 => pos%get_child(side)
-!!$      child1 => pos%get_child(1-side)
-!!$      otherchild => other%get_child(side)
-!!$      otherparent => other%parent
-!!$      other%parent => parent
-!!$      if (associated(parent)) then
-!!$         call parent%set_child(parent%which_child(pos), other)
-!!$      else
-!!$!!! TODO: needs more thought
-!!$  !!$         this%root => other
-!!$         allocate(this%root, source=other)
-!!$      endif
-!!$      call other%set_child(1-side, child1)
-!!$      if (associated(child1)) child1%parent => other
-!!$      if (associated(other, target=child0)) then
-!!$         call this%rebalance(other, .false.)
-!!$      else
-!!$         call other%set_child(side, child0)
-!!$         child0%parent => other
-!!$         call otherparent%set_child(1-side, otherchild)
-!!$         if (associated(otherchild)) otherchild%parent => otherparent
-!!$         call this%rebalance(otherparent, .false.)
-!!$      endif
-!!$!!! TODO: needs more thought
-!!$  !!$      pos%left => null()
-!!$  !!$      pos%right => null()
-!!$      deallocate(pos%left)
-!!$      deallocate(pos%right)
-!!$      deallocate(pos)
+      select case (other%which_side_am_i())
+      case (__LEFT)
+         call move_alloc(from=otherparent%left, to=tmp_other)
+      case (__RIGHT)
+         call move_alloc(from=otherparent%right, to=tmp_other)
+      end select
+
+      call tmp_other%set_parent(parent) 
+      if (associated(parent)) then
+         select case (pos%which_side_am_i())
+         case (__LEFT)
+            call move_alloc(from=parent%left, to=tmp_pos)
+            call move_alloc(from=tmp_other, to=parent%left)
+         case (__RIGHT)
+            call move_alloc(from=parent%right, to=tmp_pos)
+            call move_alloc(from=tmp_other, to=parent%right)
+         end select
+      else
+         call move_alloc(from=this%root, to=tmp_pos)
+         call move_alloc(from=tmp_other, to=this%root)
+      endif
+
+      if (associated(child1)) then
+         select type (q => tmp_pos)
+         type is (__set_node)
+            select case(side)
+            case (__LEFT)
+               call move_alloc(from=q%right, to=other%right)
+               call other%right%set_parent(other)
+            case (__RIGHT)
+               call move_alloc(from=q%left, to=other%left)
+               call other%left%set_parent(other)
+            end select
+         end select
+      end if
+
+      if (associated(other, target=child0)) then ! degenerate
+         call this%rebalance(other, .false.)
+      else
+         select type (q => tmp_pos)
+         type is (__set_node)
+            select case (side)
+            case (__LEFT)
+               call move_alloc(from=q%left, to=other%left)
+               call other%left%set_parent(other)
+            case (__RIGHT)
+               call move_alloc(from=q%right, to=other%right)
+               call other%right%set_parent(other)
+            end select
+         end select
+         if (associated(otherchild)) call otherchild%set_parent(otherparent)
+         call this%rebalance(otherparent, .false.)
+      end if
+
+      ! pos has been gutted.  We can delete the rest.
+      deallocate(tmp_pos)
       return
    end subroutine __MANGLE(erase_nonleaf)
 
@@ -894,11 +899,11 @@
       type(__set), target, intent(inout) :: source
 
       type(__set_iterator) :: iter
-!!$      type(__set_node), pointer :: parent
 
       iter = source%begin()
       do while (iter /= source%end())
          if (this%count(iter%of()) == 0) then
+            
             call this%insert(iter%of())
             iter = source%erase(iter)
          else
@@ -956,12 +961,14 @@
       integer, intent(in) :: line
 
       type(__set_node), pointer :: node
+
       print*
       print*,'At line: ', line
       if (this%size() > 0) then
          node => this%root%to_node()
          call dump(node)
       end if
+      print*
    end subroutine dump_at_line
 
    recursive subroutine dump(node)
@@ -970,24 +977,26 @@
       type(__set_node), pointer :: parent
 
       if (associated(node%parent)) then
-         write(*,'(i0,":",i0,1x,"( ")',advance='no') node%value, node%parent%value
+         write(*,'(i0,":",i0)',advance='no') node%value, node%parent%value
       else
-         write(*,'(i0,1x,"( ")',advance='no') node%value
+         write(*,'(i0,1x)',advance='no') node%value
       end if
-      if (node%has_child(__LEFT)) then
-         call dump(node%get_child(__LEFT))
-      else
-         write(*,'("* ")',advance='no')
+      if (node%has_child(__LEFT) .or. node%has_child(__RIGHT)) then
+         write(*,'(" (")', advance='no')
+         if (node%has_child(__LEFT)) then
+            call dump(node%get_child(__LEFT))
+         else
+            write(*,'(" *")', advance='no')
+         end if
+         write(*,'(" ")', advance='no')
+         if (node%has_child(__RIGHT)) then
+            call dump(node%get_child(__RIGHT))
+         else
+            write(*,'(" * ")', advance='no')
+         end if
+         write(*,'(" )")', advance='no')
       end if
-         
-      if (node%has_child(__RIGHT)) then
-         write(*,'(a1)',advance='no') '('
-         call dump(node%get_child(__RIGHT))
-         write(*,'(a1)',advance='no') ')'
-      else
-         write(*,'(" * ")',advance='no')
-      end if
-      write(*,'(" )")',advance='no')
+
    end subroutine dump
       
 

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -27,7 +27,6 @@
       type(__set) :: s
 
       s%tsize = 0
-      s%root => null()
    end function __MANGLE(new_set_empty)
 
 
@@ -59,7 +58,7 @@
    logical function __MANGLE(empty)(this) result(empty)
       class(__set), intent(in) :: this
 
-      empty = .not. associated(this%root)
+      empty = .not. allocated(this%root)
 
    end function __MANGLE(empty)
 
@@ -142,7 +141,7 @@
    subroutine __MANGLE(clear)(this)
       class(__set), intent(inout) :: this
 
-      if (associated(this%root)) deallocate(this%root)
+      if (allocated(this%root)) deallocate(this%root)
       this%tsize = 0
       return
    end subroutine __MANGLE(clear)
@@ -165,7 +164,7 @@
 
       if (present(iter)) iter%tree => this
 
-      if (associated(this%root)) then
+      if (allocated(this%root)) then
 #ifdef __set_multi
          parent => this%find_node(value, .true.)
 #else
@@ -377,9 +376,9 @@
       do while (iter /= last)
          pos => iter%node
          call iter%next()
-         if (associated(pos%right)) then
+         if (pos%has_child(__RIGHT)) then
             call this%erase_nonleaf(pos, __RIGHT)
-         else if (associated(pos%left)) then
+         else if (pos%has_child(__LEFT)) then
             call this%erase_nonleaf(pos, __LEFT)
          else
             parent => pos%parent
@@ -387,7 +386,9 @@
                call parent%set_child(parent%which_child(pos), null())
                call this%rebalance(parent, .false.)
             else
-               this%root => null()
+!!! TODO - will this come out in the wash?
+!!$               this%root => null()
+               deallocate(this%root)
             endif
             deallocate(pos)
          endif
@@ -474,7 +475,7 @@
 !!$      if (present(pos)) then
 !!$         if (associated(pos%left)) call this%write_formatted(pos%left)
 !!$         write(*, *)pos%value, loc(pos), loc(pos%parent), loc(pos%left),  &
-!!$              &       loc(pos%right), pos%height
+!!$              &       loc(pos%right), pos%get_height()
 !!$         if (associated(pos%right)) call this%write_formatted(pos%right)
 !!$      else
 !!$         write(*, *)'size=',this%getsize()
@@ -500,8 +501,8 @@
             if (.not. last .and. (                                           &
                  &     (__MANGLE(order_eq)(find_node%value,value)))) return
             side=merge(__LEFT, __RIGHT, __MANGLE(lessThan)(value, find_node%value))
-            if (.not.associated(find_node%child(side))) return
-            find_node => find_node%child(side)
+            if (.not.associated(find_node%get_child(side))) return
+            find_node => find_node%get_child(side)
          end do
       end if
 
@@ -523,18 +524,19 @@
       do while (associated(curr))
          hl=0
          hr=0
-         if (associated(curr%left)) hl=curr%left%height
-         if (associated(curr%right)) hr=curr%right%height
+         if (curr%has_child(__LEFT)) hl=curr%left%get_height()
+         if (curr%has_child(__RIGHT)) hr=curr%right%get_height()
+
          unbalanced=abs(hl-hr)>1
          if (unbalanced) then
             side=merge(__LEFT, __RIGHT, hl > hr)
-            child => curr%child(side)
+            child => curr%get_child(side)
             chl=0
             chr=0
-            if (associated(child%left)) chl=child%left%height
-            if (associated(child%right)) chr=child%right%height
+            if (child%has_child(__LEFT)) chl=child%left%get_height()
+            if (child%has_child(__RIGHT)) chr=child%right%get_height()
             if (chr/=chl) then
-               childside=merge(__LEFT, __RIGHT, chl>chr)
+               childside=merge(__LEFT, __RIGHT, chl > chr)
                if (side/=childside) call this%rot(child, 1-childside)
                call this%rot(curr, 1-side)
             endif
@@ -559,15 +561,17 @@
       parent => pos%parent
       other => pos
       call this%advpos(other, side)
-      child0 => pos%child(side)
-      child1 => pos%child(1-side)
-      otherchild => other%child(side)
+      child0 => pos%get_child(side)
+      child1 => pos%get_child(1-side)
+      otherchild => other%get_child(side)
       otherparent => other%parent
       other%parent => parent
       if (associated(parent)) then
          call parent%set_child(parent%which_child(pos), other)
       else
-         this%root => other
+!!! TODO: needs more thought
+!!$         this%root => other
+         allocate(this%root, source=other)
       endif
       call other%set_child(1-side, child1)
       if (associated(child1)) child1%parent => other
@@ -580,8 +584,11 @@
          if (associated(otherchild)) otherchild%parent => otherparent
          call this%rebalance(otherparent, .false.)
       endif
-      pos%left => null()
-      pos%right => null()
+!!! TODO: needs more thought
+!!$      pos%left => null()
+!!$      pos%right => null()
+      deallocate(pos%left)
+      deallocate(pos%right)
       deallocate(pos)
       return
    end subroutine __MANGLE(erase_nonleaf)
@@ -596,21 +603,21 @@
       type(__set_node), pointer :: prev
 
       if (.not.associated(pos)) then
-         if (.not.associated(this%root)) return
+         if (.not. allocated(this%root)) return
          pos => this%root
-         do while (associated(pos%child(1-dir)))
-            pos => pos%child(1-dir)
+         do while (associated(pos%get_child(1-dir)))
+            pos => pos%get_child(1-dir)
          end do
-      else if (associated(pos%child(dir))) then
-         pos => pos%child(dir)
-         do while (associated(pos%child(1-dir)))
-            pos => pos%child(1-dir)
+      else if (associated(pos%get_child(dir))) then
+         pos => pos%get_child(dir)
+         do while (associated(pos%get_child(1-dir)))
+            pos => pos%get_child(1-dir)
          end do
       else
          prev => pos
          pos => pos%parent
          do while (associated(pos))
-            if (.not.associated(pos%child(dir), prev)) exit
+            if (.not.associated(pos%get_child(dir), prev)) exit
             prev => pos
             pos => pos%parent
          end do
@@ -628,12 +635,14 @@
       type(__set_node), pointer :: parent, child, grandchild => null()
 
       parent => pos%parent
-      child => pos%child(1-dir)
-      if (associated(child)) grandchild => child%child(dir)
+      child => pos%get_child(1-dir)
+      if (associated(child)) grandchild => child%get_child(dir)
       if (associated(parent)) then
          call parent%set_child(parent%which_child(pos), child)
       else
-         this%root => child
+!!! TODO - root?
+!!$         this%root => child
+         allocate(this%root, source=child)
       endif
       pos%parent => child
       call pos%set_child(1-dir, grandchild)
@@ -852,12 +861,12 @@
       class(__set), target, intent(inout) :: this
       type(__set), target, intent(inout) :: x
 
-      type(__set_node), pointer :: tmp
+      class(__set_node), allocatable :: tmp
       integer(kind=GFTL_SIZE_KIND) :: tsize
 
-      tmp => this%root
-      this%root => x%root
-      x%root => tmp
+      call move_alloc(from=this%root, to=tmp)
+      call move_alloc(from=x%root, to=this%root)
+      call move_alloc(from=tmp, to=x%root)
 
       tsize = this%tsize
       this%tsize = x%tsize
@@ -874,6 +883,7 @@
 #undef __LEFT
 #undef __RIGHT
 #undef __set_node
+#undef __base_node
 
    ! undef derived template parameters
 #include "parameters/T/undef_derived_macros.inc"

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -155,13 +155,12 @@
       type (KeywordEnforcer), optional :: unused
       logical, optional, intent(out) :: is_new
       type(__set_iterator), optional, intent(out) :: iter
-      type(__set_node), pointer :: new
+      type(__set_node), target, allocatable :: new
       type(__set_node), pointer :: parent
 
       type(__set_node), pointer :: r
 
-      if (present(unused)) print*,shape(unused)
-
+      call dump_at_line(this, __LINE__)
       if (present(iter)) iter%tree => this
 
       if (allocated(this%root)) then
@@ -188,9 +187,9 @@
 
          allocate(new)
          if (present(iter)) iter%node => new
-         new%parent => parent
+         call new%set_parent(parent)
          __T_COPY__(new%value, value)
-         call parent%set_child(merge(__LEFT, __RIGHT, __T_LT__(value, parent%value)),new)
+         call parent%set_child(merge(__LEFT, __RIGHT, __T_LT__(value, parent%get_value())),new)
          call this%rebalance(parent, .true.)
       else
          allocate(this%root)
@@ -202,7 +201,10 @@
          end if
       endif
       this%tsize = this%tsize + 1
+      call dump_at_line(this, __LINE__)
       return
+      if (present(unused)) print*,shape(unused)
+
    end subroutine __MANGLE(insert_single)
 
 
@@ -558,38 +560,38 @@
       type(__set_node), pointer :: parent, other, child0, child1
       type(__set_node), pointer :: otherchild, otherparent
 
-      parent => pos%parent
-      other => pos
-      call this%advpos(other, side)
-      child0 => pos%get_child(side)
-      child1 => pos%get_child(1-side)
-      otherchild => other%get_child(side)
-      otherparent => other%parent
-      other%parent => parent
-      if (associated(parent)) then
-         call parent%set_child(parent%which_child(pos), other)
-      else
-!!! TODO: needs more thought
-!!$         this%root => other
-         allocate(this%root, source=other)
-      endif
-      call other%set_child(1-side, child1)
-      if (associated(child1)) child1%parent => other
-      if (associated(other, target=child0)) then
-         call this%rebalance(other, .false.)
-      else
-         call other%set_child(side, child0)
-         child0%parent => other
-         call otherparent%set_child(1-side, otherchild)
-         if (associated(otherchild)) otherchild%parent => otherparent
-         call this%rebalance(otherparent, .false.)
-      endif
-!!! TODO: needs more thought
-!!$      pos%left => null()
-!!$      pos%right => null()
-      deallocate(pos%left)
-      deallocate(pos%right)
-      deallocate(pos)
+!!$      parent => pos%parent
+!!$      other => pos
+!!$      call this%advpos(other, side)
+!!$      child0 => pos%get_child(side)
+!!$      child1 => pos%get_child(1-side)
+!!$      otherchild => other%get_child(side)
+!!$      otherparent => other%parent
+!!$      other%parent => parent
+!!$      if (associated(parent)) then
+!!$         call parent%set_child(parent%which_child(pos), other)
+!!$      else
+!!$!!! TODO: needs more thought
+!!$  !!$         this%root => other
+!!$         allocate(this%root, source=other)
+!!$      endif
+!!$      call other%set_child(1-side, child1)
+!!$      if (associated(child1)) child1%parent => other
+!!$      if (associated(other, target=child0)) then
+!!$         call this%rebalance(other, .false.)
+!!$      else
+!!$         call other%set_child(side, child0)
+!!$         child0%parent => other
+!!$         call otherparent%set_child(1-side, otherchild)
+!!$         if (associated(otherchild)) otherchild%parent => otherparent
+!!$         call this%rebalance(otherparent, .false.)
+!!$      endif
+!!$!!! TODO: needs more thought
+!!$  !!$      pos%left => null()
+!!$  !!$      pos%right => null()
+!!$      deallocate(pos%left)
+!!$      deallocate(pos%right)
+!!$      deallocate(pos)
       return
    end subroutine __MANGLE(erase_nonleaf)
 
@@ -634,24 +636,68 @@
       integer, intent(in) :: dir
       type(__set_node), pointer :: parent, child, grandchild => null()
 
+      class(__base_node), allocatable :: t_pos, t_child, t_grandchild
+      integer :: pos_side
+      
       parent => pos%parent
       child => pos%get_child(1-dir)
-      if (associated(child)) grandchild => child%get_child(dir)
+
       if (associated(parent)) then
-         call parent%set_child(parent%which_child(pos), child)
+         pos_side = pos%which_side_am_i()
+         select case (pos_side)
+         case (__LEFT)
+            call move_alloc(from=parent%left, to=t_pos)
+         case (__RIGHT)
+            call move_alloc(from=parent%right, to=t_pos)
+         end select
       else
-!!! TODO - root?
-!!$         this%root => child
-         allocate(this%root, source=child)
+         ! pos is root so we use tmp as a fake parent
+         call move_alloc(from=this%root, to=t_pos) ! side is arbitrary (maybe)
       endif
-      pos%parent => child
-      call pos%set_child(1-dir, grandchild)
+
       if (associated(child)) then
-         child%parent => parent
-         call child%set_child(dir, pos)
-         if (associated(grandchild)) grandchild%parent => pos
-      endif
-      call pos%update_height()
+          select case (dir)
+          case (__LEFT)
+             call move_alloc(from=pos%left, to=t_child)
+          case (__RIGHT)
+             call move_alloc(from=pos%right, to=t_child)
+          end select
+       end if
+       grandchild => child%get_child(dir)
+
+       if (associated(grandchild)) then
+!!$          select case(dir)
+!!$          case (__LEFT)
+!!$             call move_alloc(..., to=pos%right)
+!!$          case (__RIGHT)
+!!$             call move_alloc(..., to=pos%left)
+!!$          end select
+       end if
+
+
+       ! fix up pointers to parents
+       if (associated(child)) then
+          call child%set_parent(parent)
+       end if
+
+       if (associated(child)) then
+          call pos%set_parent(child)
+       end if
+
+       if (associated(grandchild)) then
+          call grandchild%set_parent(pos)
+       end if
+
+
+!!$      pos%parent => child
+!!$      call pos%set_child(1-dir, grandchild)
+!!$      if (associated(child)) then
+!!$         child%parent => parent
+!!$         call child%set_child(dir, pos)
+!!$         if (associated(grandchild)) grandchild%parent => pos
+!!$      endif
+!!$      call pos%update_height()
+
       if (associated(child)) call child%update_height()
       return
    end subroutine __MANGLE(rot)
@@ -876,6 +922,43 @@
    end subroutine __MANGLE(swap)
 
 
+   subroutine dump_at_line(this, line)
+      type(__set), target, intent(in) :: this
+      integer, intent(in) :: line
+
+      type(__set_node), pointer :: node
+      print*
+      print*,'At line: ', line
+      if (this%size() > 0) then
+         write(*,'(a1)',advance='no') '('
+         node => this%root
+         call dump(node)
+         write(*,'(a1)',advance='no') ')'
+      end if
+   end subroutine dump_at_line
+
+   recursive subroutine dump(node)
+      type(__set_node), target, intent(in) :: node
+      type(__set_node), pointer :: left, right
+
+      write(*,'(i2.0,1x)',advance='no') node%value
+      if (node%has_child(__LEFT)) then
+         write(*,'(a1)',advance='no') '('
+         call dump(node%get_child(__LEFT))
+         write(*,'(a1)',advance='no') ')'
+      else
+         write(*,'(" * ")',advance='no')
+      end if
+         
+      if (node%has_child(__RIGHT)) then
+         write(*,'(a1)',advance='no') '('
+         call dump(node%get_child(__RIGHT))
+         write(*,'(a1)',advance='no') ')'
+      else
+         write(*,'(" * ")',advance='no')
+      end if
+   end subroutine dump
+      
 
 #include "set/iterator_procedures.inc"
 

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -477,6 +477,11 @@
       logical, intent(in) :: last
       integer :: side
 
+      if (.not. allocated(this%root)) then
+         find_node => null()
+         return
+      end if
+
       find_node => this%root%to_node()
       if (associated(find_node)) then
          do
@@ -976,26 +981,26 @@ subroutine __MANGLE(erase_nonleaf)(this, pos, side)
       type(__set_node), pointer :: left, right
       type(__set_node), pointer :: parent
 
-      if (associated(node%parent)) then
-         write(*,'(i0,":",i0)',advance='no') node%value, node%parent%value
-      else
-         write(*,'(i0,1x)',advance='no') node%value
-      end if
-      if (node%has_child(__LEFT) .or. node%has_child(__RIGHT)) then
-         write(*,'(" (")', advance='no')
-         if (node%has_child(__LEFT)) then
-            call dump(node%get_child(__LEFT))
-         else
-            write(*,'(" *")', advance='no')
-         end if
-         write(*,'(" ")', advance='no')
-         if (node%has_child(__RIGHT)) then
-            call dump(node%get_child(__RIGHT))
-         else
-            write(*,'(" * ")', advance='no')
-         end if
-         write(*,'(" )")', advance='no')
-      end if
+!!$      if (associated(node%parent)) then
+!!$         write(*,'(i0,":",i0)',advance='no') node%value, node%parent%value
+!!$      else
+!!$         write(*,'(i0,1x)',advance='no') node%value
+!!$      end if
+!!$      if (node%has_child(__LEFT) .or. node%has_child(__RIGHT)) then
+!!$         write(*,'(" (")', advance='no')
+!!$         if (node%has_child(__LEFT)) then
+!!$            call dump(node%get_child(__LEFT))
+!!$         else
+!!$            write(*,'(" *")', advance='no')
+!!$         end if
+!!$         write(*,'(" ")', advance='no')
+!!$         if (node%has_child(__RIGHT)) then
+!!$            call dump(node%get_child(__RIGHT))
+!!$         else
+!!$            write(*,'(" * ")', advance='no')
+!!$         end if
+!!$         write(*,'(" )")', advance='no')
+!!$      end if
 
    end subroutine dump
       

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -98,7 +98,7 @@
       find%node => this%find_node(value, .false.)
 
       if (associated(find%node)) then
-         if (.not. __MANGLE(order_eq)(find%node%value,value)) then
+         if (.not. __MANGLE(order_eq)(find%node%get_value(),value)) then
             find%node => null()
          end if
       end if
@@ -156,9 +156,9 @@
       logical, optional, intent(out) :: is_new
       type(__set_iterator), optional, intent(out) :: iter
       type(__set_node), target, allocatable :: new
-      type(__set_node), pointer :: parent
+      class(__base_node), pointer :: parent
 
-      type(__set_node), pointer :: r
+      class(__base_node), pointer :: r
 
       call dump_at_line(this, __LINE__)
       if (present(iter)) iter%tree => this
@@ -168,12 +168,12 @@
          parent => this%find_node(value, .true.)
 #else
          parent => this%find_node(value, .false.)
-         if (__MANGLE(order_eq)(parent%value, value)) then
+         if (__MANGLE(order_eq)(parent%get_value(), value)) then
             if (present(iter)) then
                iter%node => parent
             else
                __T_FREE__(parent%value)
-               __T_COPY__(parent%value, value)
+               call parent%set_value(value)
             endif
             if (present(is_new)) then
                is_new = .false.
@@ -192,10 +192,11 @@
          call parent%set_child(merge(__LEFT, __RIGHT, __T_LT__(value, parent%get_value())),new)
          call this%rebalance(parent, .true.)
       else
-         allocate(this%root)
+         allocate(__set_node :: this%root)
          if (present(iter)) iter%node => this%root
          r => this%root
-         __T_COPY__(r%value, value)
+         call r%set_value(value)
+!!$         __T_COPY__(r%value, value)
          if (present(is_new)) then
             is_new = .true.
          end if
@@ -368,7 +369,8 @@
       class(__set), intent(inout) :: this
       type(__set_iterator), intent(in) :: first
       type(__set_iterator), intent(in) :: last
-      type(__set_node), pointer :: pos, parent
+      type(__set_node), pointer :: parent
+      class(__base_node), pointer :: pos
 
       type (__set_iterator) :: iter
 
@@ -383,7 +385,7 @@
          else if (pos%has_child(__LEFT)) then
             call this%erase_nonleaf(pos, __LEFT)
          else
-            parent => pos%parent
+            parent => pos%get_parent()
             if (associated(parent)) then
                call parent%set_child(parent%which_child(pos), null())
                call this%rebalance(parent, .false.)
@@ -491,7 +493,7 @@
    !  find_node
    ! =======================
    function __MANGLE(find_node)(this, value, last) result(find_node)
-      type(__set_node), pointer :: find_node
+      class(__base_node), pointer :: find_node
       class(__set), target, intent(in) :: this
       __T_declare_dummy__, intent(in) :: value
       logical, intent(in) :: last
@@ -501,8 +503,8 @@
       if (associated(find_node)) then
          do
             if (.not. last .and. (                                           &
-                 &     (__MANGLE(order_eq)(find_node%value,value)))) return
-            side=merge(__LEFT, __RIGHT, __MANGLE(lessThan)(value, find_node%value))
+                 &     (__MANGLE(order_eq)(find_node%get_value(),value)))) return
+            side=merge(__LEFT, __RIGHT, __MANGLE(lessThan)(value, find_node%get_value()))
             if (.not.associated(find_node%get_child(side))) return
             find_node => find_node%get_child(side)
          end do
@@ -519,7 +521,7 @@
       type(__set_node), pointer, intent(in) :: pos
       logical, intent(in) :: once
       type(__set_node), pointer :: curr, child
-      integer :: hl, hr, chl, chr, side, childside
+      integer :: hl, hr, chl, chr, side, child_side
       logical :: unbalanced
 
       curr => pos
@@ -530,16 +532,18 @@
          if (curr%has_child(__RIGHT)) hr=curr%right%get_height()
 
          unbalanced=abs(hl-hr)>1
+         print*,__FILE__,__LINE__,'unbalanced? ', unbalanced, hl, hr
          if (unbalanced) then
-            side=merge(__LEFT, __RIGHT, hl > hr)
+            side = merge(__LEFT, __RIGHT, hl > hr)
             child => curr%get_child(side)
-            chl=0
-            chr=0
-            if (child%has_child(__LEFT)) chl=child%left%get_height()
-            if (child%has_child(__RIGHT)) chr=child%right%get_height()
-            if (chr/=chl) then
-               childside=merge(__LEFT, __RIGHT, chl > chr)
-               if (side/=childside) call this%rot(child, 1-childside)
+            chl = 0
+            chr = 0
+            if (child%has_child(__LEFT)) chl = child%left%get_height()
+            if (child%has_child(__RIGHT)) chr = child%right%get_height()
+            if (chr /= chl) then
+               child_side=merge(__LEFT, __RIGHT, chl > chr)
+               print*,__FILE__,__LINE__, 'same side?',side, child_side
+               if (side /= child_side) call this%rot(child, 1-child_side)
                call this%rot(curr, 1-side)
             endif
          endif
@@ -555,7 +559,8 @@
    ! =======================
    subroutine __MANGLE(erase_nonleaf)(this, pos, side)
       class(__set), intent(inout) :: this
-      type(__set_node), pointer, intent(inout) :: pos
+!!$      type(__set_node), pointer, intent(inout) :: pos
+      class(__base_node), pointer, intent(inout) :: pos
       integer, intent(in) :: side
       type(__set_node), pointer :: parent, other, child0, child1
       type(__set_node), pointer :: otherchild, otherparent
@@ -636,70 +641,92 @@
       integer, intent(in) :: dir
       type(__set_node), pointer :: parent, child, grandchild => null()
 
-      class(__base_node), allocatable :: t_pos, t_child, t_grandchild
+      class(__base_node), allocatable :: A, B, C
       integer :: pos_side
       
       parent => pos%parent
-      child => pos%get_child(1-dir)
 
       if (associated(parent)) then
          pos_side = pos%which_side_am_i()
          select case (pos_side)
          case (__LEFT)
-            call move_alloc(from=parent%left, to=t_pos)
+            call move_alloc(from=parent%left, to=A)
          case (__RIGHT)
-            call move_alloc(from=parent%right, to=t_pos)
+            call move_alloc(from=parent%right, to=A)
          end select
       else
-         ! pos is root so we use tmp as a fake parent
-         call move_alloc(from=this%root, to=t_pos) ! side is arbitrary (maybe)
+         call move_alloc(from=this%root, to=A)
       endif
 
+      child => pos%get_child(1-dir)
       if (associated(child)) then
-          select case (dir)
-          case (__LEFT)
-             call move_alloc(from=pos%left, to=t_child)
-          case (__RIGHT)
-             call move_alloc(from=pos%right, to=t_child)
-          end select
-       end if
-       grandchild => child%get_child(dir)
+         select case (1-dir)
+         case (__LEFT)
+            call move_alloc(from=pos%left, to=B)
+         case (__RIGHT)
+            call move_alloc(from=pos%right, to=B)
+         end select
+      else
+         error stop "isn't there always a child for rot?"
+      end if
+      
+      grandchild => child%get_child(dir)
+      if (associated(grandchild)) then
+         select case (dir)
+         case (__LEFT)
+            call move_alloc(from=child%left, to=C)
+         case (__RIGHT)
+            call move_alloc(from=child%right, to=C)
+         end select
+      end if
 
-       if (associated(grandchild)) then
-!!$          select case(dir)
-!!$          case (__LEFT)
-!!$             call move_alloc(..., to=pos%right)
-!!$          case (__RIGHT)
-!!$             call move_alloc(..., to=pos%left)
-!!$          end select
-       end if
+      if (associated(grandchild)) then
+         select type (A)
+         type is (__set_node)
+            select case (1-dir)
+            case (__LEFT)
+               call move_alloc(from=C, to=A%left)
+            case (__RIGHT)
+               call move_alloc(from=C, to=A%right)
+            end select
+         end select
+         call grandchild%set_parent(pos)
+      end if
 
+      if (associated(child)) then
+         select type (B)
+         type is (__set_node)
+            select case (dir)
+            case (__LEFT)
+               call move_alloc(from=A, to=B%left)
+            case (__RIGHT)
+               call move_alloc(from=A, to=B%right)
+            end select
+         end select
+         call pos%set_parent(child)
+      end if
+      
+      if (associated(parent)) then
+         select case (pos_side)
+         case (__LEFT)
+            call move_alloc(from=B, to=parent%left)
+         case (__RIGHT)
+            call move_alloc(from=B, to=parent%right)
+         end select
+      else
+         call move_alloc(from=B, to=this%root)
+      endif
+      call child%set_parent(parent)
 
-       ! fix up pointers to parents
-       if (associated(child)) then
-          call child%set_parent(parent)
-       end if
-
-       if (associated(child)) then
-          call pos%set_parent(child)
-       end if
-
-       if (associated(grandchild)) then
-          call grandchild%set_parent(pos)
-       end if
-
-
-!!$      pos%parent => child
-!!$      call pos%set_child(1-dir, grandchild)
-!!$      if (associated(child)) then
-!!$         child%parent => parent
-!!$         call child%set_child(dir, pos)
-!!$         if (associated(grandchild)) grandchild%parent => pos
-!!$      endif
-!!$      call pos%update_height()
-
+      call pos%update_height()
       if (associated(child)) call child%update_height()
       return
+   contains
+
+      subroutine cheat(a,b)
+         type(__set_node), allocatable :: a, b
+         call move_alloc(from=a, to=b)
+      end subroutine cheat
    end subroutine __MANGLE(rot)
 
    logical function __MANGLE(value_compare)(this, x, y) result(value_compare)
@@ -930,24 +957,25 @@
       print*
       print*,'At line: ', line
       if (this%size() > 0) then
-         write(*,'(a1)',advance='no') '('
          node => this%root
          call dump(node)
-         write(*,'(a1)',advance='no') ')'
       end if
    end subroutine dump_at_line
 
    recursive subroutine dump(node)
       type(__set_node), target, intent(in) :: node
       type(__set_node), pointer :: left, right
+      type(__set_node), pointer :: parent
 
-      write(*,'(i2.0,1x)',advance='no') node%value
-      if (node%has_child(__LEFT)) then
-         write(*,'(a1)',advance='no') '('
-         call dump(node%get_child(__LEFT))
-         write(*,'(a1)',advance='no') ')'
+      if (associated(node%parent)) then
+         write(*,'(i0,":",i0,1x,"( ")',advance='no') node%value, node%parent%value
       else
-         write(*,'(" * ")',advance='no')
+         write(*,'(i0,1x,"( ")',advance='no') node%value
+      end if
+      if (node%has_child(__LEFT)) then
+         call dump(node%get_child(__LEFT))
+      else
+         write(*,'("* ")',advance='no')
       end if
          
       if (node%has_child(__RIGHT)) then
@@ -957,6 +985,7 @@
       else
          write(*,'(" * ")',advance='no')
       end if
+      write(*,'(" )")',advance='no')
    end subroutine dump
       
 

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -644,7 +644,7 @@ subroutine __MANGLE(erase_nonleaf)(this, pos, side)
    ! =======================
    subroutine __MANGLE(rot)(this, pos, dir)
       class(__set), intent(inout) :: this
-      type(__set_node), pointer, intent(in) :: pos
+      type(__set_node), pointer, intent(inout) :: pos
       integer, intent(in) :: dir
       type(__set_node), pointer :: parent, child, grandchild => null()
 

--- a/include/v2/set/specification.inc
+++ b/include/v2/set/specification.inc
@@ -33,7 +33,7 @@
 #include "set/node_specification.inc"   
    type :: __set
       private
-      class(__set_node), allocatable :: root
+      class(__base_node), allocatable :: root
       integer(kind=GFTL_SIZE_KIND) :: tsize = 0
    contains
       procedure :: empty => __MANGLE(empty)

--- a/include/v2/set/specification.inc
+++ b/include/v2/set/specification.inc
@@ -15,6 +15,7 @@
 
 #define __LEFT 0
 #define __RIGHT 1
+#define __base_node __MANGLE(BaseNode)
 #define __set_node __MANGLE(Node)
 
    ! Structure constructors
@@ -29,7 +30,7 @@
 #endif
    end interface __set
 
-#include "set/node_specifiation.inc"   
+#include "set/node_specification.inc"   
    type :: __set
       private
       class(__set_node), allocatable :: root
@@ -122,6 +123,7 @@
 #undef __LEFT
 #undef __RIGHT
 #undef __set_node
+#undef __base_node
 
 ! undef derived template parameters
 #include "parameters/T/undef_derived_macros.inc"

--- a/include/v2/set/specification.inc
+++ b/include/v2/set/specification.inc
@@ -29,24 +29,10 @@
 #endif
    end interface __set
 
-   type :: __set_node
-      type(__set_node), pointer :: parent => null()
-      type(__set_node), pointer :: left => null()
-      type(__set_node), pointer :: right => null()
-      integer :: height=1
-      __T_declare_component__ :: value
-   contains
-      procedure :: child => __MANGLE(child)
-      procedure :: which_child => __MANGLE(which_child)
-      procedure :: set_child => __MANGLE(set_child)
-      procedure, private :: update_height => __MANGLE(update_height)
-      final :: __MANGLE(finalize_node)
-   end type __set_node
-      
-
+#include "set/node_specifiation.inc"   
    type :: __set
       private
-      type(__set_node), pointer :: root => null()
+      class(__set_node), allocatable :: root
       integer(kind=GFTL_SIZE_KIND) :: tsize = 0
    contains
       procedure :: empty => __MANGLE(empty)
@@ -102,7 +88,6 @@
       ! key_compare() and value_compare() are the same thing for Set.
       procedure :: key_compare => __MANGLE(value_compare)
       procedure :: value_compare => __MANGLE(value_compare)
-      final :: __MANGLE(finalize_set)
 
    end type __set
 

--- a/include/v2/shared/define_common_macros.inc
+++ b/include/v2/shared/define_common_macros.inc
@@ -5,7 +5,8 @@
 ! Per-container name mangling   
 #    define __IDENTITY(x) x
 #    define __COMMA(x) , x
-#    define __MANGLE(proc) __IDENTITY(proc)__IDENTITY(_)__IDENTITY(__guard)
+#    define __MANGLE(proc) __IDENTITY(__guard)__IDENTITY(proc)
+!#    define __MANGLE(proc) __IDENTITY(proc)__IDENTITY(_)__IDENTITY(__guard)
 
 ! Fortran portability support
 #    ifdef  gftl_size_kind

--- a/include/v2/shared/define_common_macros.inc
+++ b/include/v2/shared/define_common_macros.inc
@@ -5,7 +5,7 @@
 ! Per-container name mangling   
 #    define __IDENTITY(x) x
 #    define __COMMA(x) , x
-#    define __MANGLE(proc) __IDENTITY(__guard)__IDENTITY(proc)
+#    define __MANGLE(proc) __IDENTITY(proc)__IDENTITY(_)__IDENTITY(__guard)
 
 ! Fortran portability support
 #    ifdef  gftl_size_kind

--- a/tests/v1/shared/pFUnitSupplement.F90
+++ b/tests/v1/shared/pFUnitSupplement.F90
@@ -9,7 +9,6 @@
 
 
 module pFUnitSupplement_mod
-   use funit, only: shadowAssert => assertEqual
    use funit, only: SourceLocation
    use funit, only: throw
    use iso_fortran_env, only: INT64
@@ -28,6 +27,7 @@ contains
 
 
    subroutine assertEqual_unlimited(a, b, location)
+      use funit, only: shadowAssert => assertEqual
       class (*), intent(in) :: a
       class (*), intent(in) :: b
       type (SourceLocation), intent(in) :: location
@@ -35,8 +35,10 @@ contains
       select type (pa => a)
 
       type is (integer)
+         print*,__FILE__,__LINE__
          select type (pb => b)
          type is (integer)
+            print*,__FILE__,__LINE__
             call shadowAssert(pa, pb, location=location)
          type is (integer(kind=INT64))
             call shadowAssert(pa, pb, location=location)


### PR DESCRIPTION
This sidesteps any issues compilers have with complex FINAL methods in trees based on pointers.

The tree in SET now uses allocatable components for child components.   Implementation is made difficult by the fact that not all compilers support recursive allocatable structures.  So the Surrogate pattern is used to do this indirectly.