### PR TITLE
Fix spelling of SUCCESS

### DIFF
--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixed
+
+- Fix misspelling of SUCCESS
+
 ## [1.7.0] - 2022-04-08
 
 ### Changed

--- a/cmake/CheckFortranSource.cmake
+++ b/cmake/CheckFortranSource.cmake
@@ -81,7 +81,7 @@ macro (CHECK_Fortran_SOURCE_COMPILE file var)
 
   if (${var})
     if (NOT CMAKE_REQUIRED_QUIET)
-      message(STATUS "Performing Test ${var}: SUCCESSS")
+      message(STATUS "Performing Test ${var}: SUCCESS")
     endif ()
 
     add_definitions(-D${var})


### PR DESCRIPTION
Minor fix: Fix a misspelling of SUCCESS.