### PR TITLE
Feature/cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if (COMMAND cmake_policy)
 endif (COMMAND cmake_policy)
 
 project (GFTL
-  VERSION 1.7.2
+  VERSION 1.8.0
   LANGUAGES NONE)
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -9,6 +9,8 @@
 
 ## Fixed
 
+- Fixed bug in `vector::insert_range()` (needs a unit test)
+
 - Added `TARGET` to some dummy arguments to prevent NAG from doing copy-in / copy-out.  Seems to 
   have been causing a memory corruption issue with the yaFyaml package, but might indicate a bug
   in yaFyaml (or gFTL).

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -2,13 +2,26 @@
 
 ## Unreleased
 
+## Changed
+
+- Interfaces (intents) to map::at() and ordered_map::at().  The self object should be `INTENT(IN)` for these interfaces.
+
+
 ## Fixed
 
-- Fixed bug in interface to map::at() and ordered_map::at().  The self object should be `INTENT(IN)` for these interfaces.
+- Added `TARGET` to some dummy arguments to prevent NAG from doing copy-in / copy-out.  Seems to 
+  have been causing a memory corruption issue with the yaFyaml package, but might indicate a bug
+  in yaFyaml (or gFTL).
 
 - Fixed non-standard-conforming mismatched integer KIND in deque implementation.
 
 - Fixed misspelling of SUCCESS
+
+## Removed
+
+- Various unused local variables that were causing annoying compiler warnings.
+
+
 
 ## [1.7.2] - 2022-05-08
 

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [1.8.0] - 2022-05-31
+
 ## Changed
 
 - Interfaces (intents) to map::at() and ordered_map::at().  The self object should be `INTENT(IN)` for these interfaces.

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -4,7 +4,11 @@
 
 ## Fixed
 
-- Fix misspelling of SUCCESS
+- Fixed bug in interface to map::at() and ordered_map::at().  The self object should be `INTENT(IN)` for these interfaces.
+
+- Fixed non-standard-conforming mismatched integer KIND in deque implementation.
+
+- Fixed misspelling of SUCCESS
 
 ## [1.7.2] - 2022-05-08
 

--- a/include/v2/algorithms/find/procedures.inc
+++ b/include/v2/algorithms/find/procedures.inc
@@ -30,6 +30,8 @@
          type(keywordenforcer), intent(in) :: unused
 
          j%placeholder = -1
+         __UNUSED_DUMMY(do_not_use)
+         __UNUSED_DUMMY(unused)
        end function __MANGLE(find_basic)
 #endif      
       

--- a/include/v2/deque/procedures.inc
+++ b/include/v2/deque/procedures.inc
@@ -997,7 +997,7 @@
       class(__deque), intent(in) :: this
       integer(kind=GFTL_SIZE_KIND), intent(in) :: i
 
-      bucket_offset = 1 + modulo(i-1, __deque_bucket_size__)
+      bucket_offset = 1 + modulo(i-1, int(__deque_bucket_size__,kind=GFTL_SIZE_KIND))
    end function __MANGLE(bucket_offset)
 
 #include "deque/iterator_procedures.inc"

--- a/include/v2/deque/procedures.inc
+++ b/include/v2/deque/procedures.inc
@@ -38,6 +38,16 @@
 ! define derived generic template parameters from internal parameters.
 #include "parameters/T/define_derived_macros.inc"
 
+
+   subroutine __MANGLE(unused_procedure)()
+      ! The following are an adhoc way to suppress compiler
+      ! warnings about parameters not used in this template
+      __UNUSED_DUMMY(BAD_ALLOC)
+      __UNUSED_DUMMY(TYPE_HAS_NO_DEFAULT_VALUE)
+      __UNUSED_DUMMY(NO_TYPE__)
+   end subroutine __MANGLE(unused_procedure)
+
+
    ! =======================
    !  Structure constructors
    ! =======================
@@ -200,7 +210,7 @@
          rc = OUT_OF_RANGE
          res => null()
       else
-         rc = 0
+         rc = SUCCESS
          res => this%buckets(this%idx(i))%ptr%bucket_items%item
       end if
 
@@ -283,6 +293,7 @@
       ii = this%idx(i)
       __T_FREE__(this%buckets(ii)%ptr%bucket_items%item)
       __T_COPY__(this%buckets(ii)%ptr%bucket_items%item, value)
+
 
       return
    end subroutine __MANGLE(set_size_kind)
@@ -569,13 +580,13 @@
       integer, optional, intent(out) :: rc
 
       integer(kind=GFTL_SIZE_KIND) :: old_size
-      integer(kind=GFTL_SIZE_KIND) :: i, ii
       integer :: status
-
-      __UNUSED_DUMMY(unused)
+#if defined(__T_FREE__)
+      integer(kind=GFTL_SIZE_KIND) :: i, ii
+#endif
 
       if (count == this%size_) then
-         if (present(rc)) rc = 0
+         if (present(rc)) rc = SUCCESS
          return
       end if
       if (count < 0) then
@@ -583,7 +594,7 @@
          return
       end if
 
-      if (present(rc)) rc = 0
+      if (present(rc)) rc = SUCCESS
 
       old_size = this%size_
 
@@ -594,6 +605,7 @@
       end if
 
       this%size_ = count
+#if defined(__T_FREE__)
       do i = count + 1, old_size
          ii = this%idx(i)
          __T_FREE__(this%buckets(ii)%ptr%bucket_items%item)
@@ -612,8 +624,10 @@
             end do
          end if
       endif
+#endif
 
       return
+      __UNUSED_DUMMY(unused)
    end subroutine __MANGLE(resize_size_kind)
 
    subroutine __MANGLE(resize_default)(this, count, unused, value, rc)
@@ -637,14 +651,17 @@
       class(__deque), intent(inout) :: this
       integer(kind=GFTL_SIZE_KIND), intent(in) :: from, to  ! assumes newsize<=size()
 
+#if defined(__T_FREE__)
       integer(kind=GFTL_SIZE_KIND) :: i, ii
-
       if (from <= to) then
+
          do i = from, to - 1
             ii = this%idx(i)
             __T_FREE__(this%buckets(ii)%ptr%bucket_items%item)
          end do
+
       else
+
          do i = from, this%capacity()
             ii = this%idx(i)
             __T_FREE__(this%buckets(ii)%ptr%bucket_items%item)
@@ -653,7 +670,11 @@
             ii = this%idx(i)
             __T_FREE__(this%buckets(ii)%ptr%bucket_items%item)
          end do
+
       endif
+      __UNUSED_DUMMY(ii)
+#endif
+
       this%size_ = this%size_ - modulo(from - to, this%capacity())  - 1
 
       return
@@ -753,7 +774,7 @@
             rc = LENGTH_ERROR
             return
          else
-            rc = 0
+            rc = SUCCESS
          end if
       end if
 
@@ -777,7 +798,7 @@
             rc = LENGTH_ERROR
             return
          else
-            rc = 0
+            rc = SUCCESS
          end if
       end if
 
@@ -981,6 +1002,10 @@
 #endif
     write(unit,'(a)') new_line('a')
     write(unit,'(4x,a10,1x,i0)') 'size: ',this%size()
+
+    __UNUSED_DUMMY(iomsg)
+    __UNUSED_DUMMY(iotype)
+    __UNUSED_DUMMY(v_list)
    end subroutine __MANGLE(write_formatted)
 
 
@@ -990,6 +1015,8 @@
       integer(kind=GFTL_SIZE_KIND), intent(in) :: i
 
       bucket_index = 1 + (i-1)/__deque_bucket_size__
+
+      __UNUSED_DUMMY(this)
    end function __MANGLE(bucket_index)
 
    function __MANGLE(bucket_offset)(this, i) result(bucket_offset)
@@ -998,6 +1025,8 @@
       integer(kind=GFTL_SIZE_KIND), intent(in) :: i
 
       bucket_offset = 1 + modulo(i-1, int(__deque_bucket_size__,kind=GFTL_SIZE_KIND))
+
+      __UNUSED_DUMMY(this)
    end function __MANGLE(bucket_offset)
 
 #include "deque/iterator_procedures.inc"

--- a/include/v2/map/procedures.inc
+++ b/include/v2/map/procedures.inc
@@ -67,6 +67,15 @@
 #include "parameters/Key/define_derived_macros.inc"
 #include "parameters/T/define_derived_macros.inc"
 
+   subroutine __MANGLE(unused_procedure)()
+      ! The following are an adhoc way to suppress compiler
+      ! warnings about parameters not used in this template
+      __UNUSED_DUMMY(BAD_ALLOC)
+      __UNUSED_DUMMY(ILLEGAL_INPUT)
+      __UNUSED_DUMMY(LENGTH_ERROR)
+      __UNUSED_DUMMY(TYPE_HAS_NO_DEFAULT_VALUE)
+      __UNUSED_DUMMY(NO_TYPE__)
+   end subroutine __MANGLE(unused_procedure)
 
 ! This constructor is needed in situations where an empty dictionary needs to be
 ! passed to a procedure.  Prevents the need of declaring a local variable.

--- a/include/v2/map/procedures.inc
+++ b/include/v2/map/procedures.inc
@@ -139,8 +139,6 @@
          __Key_declare_dummy__, intent(in) :: key
          __T_declare_dummy__, target, intent(in) :: value
 
-         integer :: sz
-
          integer, save :: depth = 0
 
          type (__map_pair) :: p
@@ -149,7 +147,6 @@
          __Key_COPY__(p%first, key)
          __T_COPY__(p%second, value)
 
-         sz = this%size()
          call this%tree%insert(p)
          depth = depth - 1
 
@@ -420,6 +417,12 @@
 
          verify = this%tree%verify()
       end function __MANGLE(verify)
+
+      recursive subroutine __MANGLE(final)(this)
+         type(__map), intent(inout) :: this
+
+         call this%clear()
+      end subroutine __MANGLE(final)
 
 
 #ifdef _DUMP_MAP

--- a/include/v2/map/procedures.inc
+++ b/include/v2/map/procedures.inc
@@ -418,12 +418,6 @@
          verify = this%tree%verify()
       end function __MANGLE(verify)
 
-      recursive subroutine __MANGLE(final)(this)
-         type(__map), intent(inout) :: this
-
-         call this%clear()
-      end subroutine __MANGLE(final)
-
 
 #ifdef _DUMP_MAP
 ! =======================

--- a/include/v2/ordered_map/procedures.inc
+++ b/include/v2/ordered_map/procedures.inc
@@ -63,7 +63,8 @@
       function __MANGLE(new_omap_empty)() result(m)
          type (__omap) :: m
 
-         if (.false.) print*,shape(m) ! avoid compiler warnings about unused
+         m%map = __MANGLE(Map)()
+         m%ordered_keys = __MANGLE(Vector)()
          
       end function __MANGLE(new_omap_empty)
 
@@ -403,6 +404,13 @@
 
          verify = this%map%verify()
       end function __MANGLE(verify)
+
+
+      recursive subroutine __MANGLE(final)(this)
+         type(__omap), intent(inout) :: this
+
+         call this%clear()
+      end subroutine __MANGLE(final)
 
 
 

--- a/include/v2/ordered_map/procedures.inc
+++ b/include/v2/ordered_map/procedures.inc
@@ -141,6 +141,7 @@
             call this%map%insert(key, value)
          end if
 
+         __UNUSED_DUMMY(tmp)
       end subroutine __MANGLE(insert_key_value)
 
 
@@ -162,7 +163,6 @@
       __Key_declare_dummy__, intent(in) :: key
       __T_declare_dummy__, intent(in) :: value
 
-      type(__omap_pair) :: p
       integer :: status
       __T_declare_result__, pointer :: v
       
@@ -175,7 +175,7 @@
       end if
 
       return
-
+      __UNUSED_DUMMY(v)
       end subroutine __MANGLE(set_)
 
 ! =======================
@@ -190,8 +190,6 @@
       __Key_declare_dummy__, intent(in) :: key
       __T_declare_result__, pointer :: res
 
-      __T_declare_result__, pointer :: v
-
       res => this%map%of(key)
 
       return
@@ -205,8 +203,6 @@
       class(__omap), target, intent(in) :: this
       __Key_declare_dummy__, intent(in) :: key
       integer, intent(out) :: rc
-
-      type (__omap_iterator) :: iter
 
       res => this%map%at(key, rc)
 
@@ -228,6 +224,7 @@
          m_iter = this%map%erase(this%map%find(iter%key_iter%of()))
          new_iter%key_iter = this%ordered_keys%erase(iter%key_iter)
 
+         __UNUSED_DUMMY(m_iter)
       end function __MANGLE(erase_iter)
 
 ! =======================
@@ -251,6 +248,8 @@
             n = 0
          end if
 
+         return
+         __UNUSED_DUMMY(iter)
       end function __MANGLE(erase_key)
 
 
@@ -345,9 +344,6 @@
          class(__omap), target, intent(in) :: this
          __Key_declare_dummy__, intent(in) :: key
 
-         type (__omap_pair) :: p
-
-         __Key_COPY__(p%first, key)
 
          iter%reference => this
          associate (b => this%ordered_keys%begin(), e => this%ordered_keys%end())

--- a/include/v2/pair/procedures.inc
+++ b/include/v2/pair/procedures.inc
@@ -86,7 +86,6 @@
       type(__pair), intent(in) :: a
       type(__pair), intent(in) :: b
 
-      logical :: gt
       logical :: lt1, lt2
 
       lt = __T1_LT__(a%first, b%first)

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -146,27 +146,10 @@
    recursive subroutine __MANGLE(clear)(this)
       class(__set), intent(inout) :: this
 
-!!$      if (allocated(this%root)) deallocate(this%root)
-      if (allocated(this%root)) call node_deallocate(this%root)
+      if (allocated(this%root)) deallocate(this%root)
 
       this%tsize = 0
       return
-
-   contains
-
-      recursive subroutine node_deallocate(node)
-         class(__base_node), allocatable, intent(inout) :: node
-
-         select type (q => node)
-         type is (__set_node)
-            if (allocated(q%left)) call node_deallocate(q%left)
-            if (allocated(q%right)) call node_deallocate(q%right)
-         end select
-
-         deallocate(node)
-
-      end subroutine node_deallocate
-
          
    end subroutine __MANGLE(clear)
 

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -157,9 +157,6 @@
       recursive subroutine node_deallocate(node)
          class(__base_node), allocatable, intent(inout) :: node
 
-         class(__base_node), pointer :: ch
-
-!!$         print*,'recursive node deallocate in set'
          select type (q => node)
          type is (__set_node)
             if (allocated(q%left)) call node_deallocate(q%left)
@@ -167,6 +164,7 @@
          end select
 
          deallocate(node)
+
       end subroutine node_deallocate
 
          
@@ -296,6 +294,8 @@
 
       call this%insert(value, iter=iter)
 
+      __UNUSED_DUMMY(unused)
+      __UNUSED_DUMMY(hint)
    end subroutine __MANGLE(insert_single_with_hint)
 
 
@@ -991,6 +991,10 @@
 #endif
     write(unit,'(a)') new_line('a')
     write(unit,'(4x,a10,1x,i0)') 'size: ',this%size()
+
+    __UNUSED_DUMMY(iomsg)
+    __UNUSED_DUMMY(iotype)
+    __UNUSED_DUMMY(v_list)
    end subroutine __MANGLE(write_formatted)
 
 

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -113,8 +113,8 @@
 
 
    logical function __MANGLE(order_eq)(x, y) result(equal)
-      __T_declare_dummy__, intent(in) :: x
-      __T_declare_dummy__, intent(in) :: y
+      __T_declare_dummy__, target, intent(in) :: x
+      __T_declare_dummy__, target, intent(in) :: y
 
       equal = .not. __MANGLE(lessThan)(x,y) .and. .not. __MANGLE(lessThan)(y,x)
    end function __MANGLE(order_eq)
@@ -146,9 +146,30 @@
    recursive subroutine __MANGLE(clear)(this)
       class(__set), intent(inout) :: this
 
-      if (allocated(this%root)) deallocate(this%root)
+!!$      if (allocated(this%root)) deallocate(this%root)
+      if (allocated(this%root)) call node_deallocate(this%root)
+
       this%tsize = 0
       return
+
+   contains
+
+      recursive subroutine node_deallocate(node)
+         class(__base_node), allocatable, intent(inout) :: node
+
+         class(__base_node), pointer :: ch
+
+!!$         print*,'recursive node deallocate in set'
+         select type (q => node)
+         type is (__set_node)
+            if (allocated(q%left)) call node_deallocate(q%left)
+            if (allocated(q%right)) call node_deallocate(q%right)
+         end select
+
+         deallocate(node)
+      end subroutine node_deallocate
+
+         
    end subroutine __MANGLE(clear)
 
    ! =======================
@@ -505,7 +526,9 @@
     if (associated(find_node)) then
        do
           if (.not. last .and. (                                           &
-               &     (__MANGLE(order_eq)(find_node%get_value(),value)))) return
+               &     (__MANGLE(order_eq)(find_node%get_value(),value)))) then
+             return
+          end if
           side=merge(__LEFT, __RIGHT, __MANGLE(lessThan)(value, find_node%get_value()))
           if (.not.associated(find_node%get_child(side))) return
           find_node => find_node%get_child(side)
@@ -891,11 +914,11 @@
       class(__set), target, intent(out) :: this
       class(__set), target, intent(in) :: other
 
-      type(__set_iterator) :: iter, iteriter
-      __T_declare_result__, pointer :: ptr, ptrptr
+      type(__set_iterator) :: iter
+      __T_declare_result__, pointer :: ptr
 
       integer, save :: depth = 0
-      integer :: counter, countercounter
+      integer :: counter
 
       if (.not. allocated(other%root)) return
 

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -113,8 +113,8 @@
 
 
    logical function __MANGLE(order_eq)(x, y) result(equal)
-      __T_declare_dummy__, target, intent(in) :: x
-      __T_declare_dummy__, target, intent(in) :: y
+      __T_declare_dummy__, intent(in) :: x
+      __T_declare_dummy__, intent(in) :: y
 
       equal = .not. __MANGLE(lessThan)(x,y) .and. .not. __MANGLE(lessThan)(y,x)
    end function __MANGLE(order_eq)

--- a/include/v2/vector/procedures.inc
+++ b/include/v2/vector/procedures.inc
@@ -379,7 +379,7 @@
       end do
 
       do i = 0, n-1
-         __T_COPY__(this%elements(pos%current_index + i)%item, first%of(i))
+         __T_COPY__(this%elements(pos%current_index + i)%item, value)
       end do
 
       this%vsize = this%vsize + n
@@ -994,6 +994,9 @@
 #endif
     write(unit,'(a)') new_line('a')
     write(unit,'(4x,a10,1x,i0)') 'size: ',this%size()
+    __UNUSED_DUMMY(iomsg)
+    __UNUSED_DUMMY(iotype)
+    __UNUSED_DUMMY(v_list)
    end subroutine __MANGLE(write_formatted)
 
 

--- a/tests/set/Test_Set.m4
+++ b/tests/set/Test_Set.m4
@@ -207,7 +207,6 @@ contains
       @assert_that(int(s%size()), is(2))
       @assert_that(int(s%count(one)), is(0))
 
-      
    end subroutine test_erase_iter
 
    @test

--- a/tests/set/Test_SetAlgorithms.m4
+++ b/tests/set/Test_SetAlgorithms.m4
@@ -76,7 +76,8 @@ contains
 
       counter = counter + 1
       p1 = (counter == 1)
-      
+
+     __UNUSED_DUMMY(value)
    end function p1
    
    logical function p2(value)
@@ -85,6 +86,7 @@ contains
       counter = counter + 1
       p2 = (counter == 2)
       
+     __UNUSED_DUMMY(value)
    end function p2
 
    subroutine reset_counter()
@@ -111,6 +113,8 @@ contains
       iter = find_if(s%begin(), s%end(), p1)
       @assert_that(counter, is(1))
 
+      ! The following line is to avoid compiler warning about not referencing iter
+      __UNUSED_DUMMY(iter)
       
    end subroutine test_if
 
@@ -125,7 +129,6 @@ contains
       call s%insert(two)
       call s%insert(three)
 
-
       call reset_counter()
       iter = find_if_not(s%begin(), s%end(), p1)
       @assert_that(counter, is(2))
@@ -133,7 +136,10 @@ contains
       call reset_counter()
       iter = find_if_not(s%begin(), s%end(), p2)
       @assert_that(counter, is(1))
-      
+
+      ! The following line is to avoid compiler warning about not referencing iter
+      __UNUSED_DUMMY(iter)
+
    end subroutine test_if_not
 
 end module Test_{}_type()SetAlgorithms

--- a/tests/vector/Test_Vector.m4
+++ b/tests/vector/Test_Vector.m4
@@ -431,9 +431,9 @@ contains
 
    @test
    subroutine test_equal()
+#if defined(__T__EQ__) || defined(__T_LT__)
       type(vector) :: ref, smaller, bigger, different
 
-#if defined(__T__EQ__) || defined(__T_LT__)
       ! [1,2]
       call ref%push_back(one)
       call ref%push_back(two)
@@ -461,9 +461,10 @@ contains
 
    @test
    subroutine test_not_equal()
-      type(vector) :: ref, smaller, bigger, different
 
 #if defined(__T_EQ__) || defined(__T_LT__)
+      type(vector) :: ref, smaller, bigger, different
+
       ! [1,2]
       call ref%push_back(one)
       call ref%push_back(two)

--- a/tests/vector/Test_VectorAlgorithms.m4
+++ b/tests/vector/Test_VectorAlgorithms.m4
@@ -78,7 +78,8 @@ contains
 
       counter = counter + 1
       p1 = (counter == 1)
-      
+
+      __UNUSED_DUMMY(value)
    end function p1
    
    logical function p2(value)
@@ -87,6 +88,7 @@ contains
       counter = counter + 1
       p2 = (counter == 2)
       
+      __UNUSED_DUMMY(value)
    end function p2
 
    subroutine reset_counter()


### PR DESCRIPTION

## Changed

- Interfaces (intents) to map::at() and ordered_map::at().  The self object should be `INTENT(IN)` for these interfaces.


## Fixed

- Fixed bug in `vector::insert_range()` (needs a unit test)

- Added `TARGET` to some dummy arguments to prevent NAG from doing copy-in / copy-out.  Seems to 
  have been causing a memory corruption issue with the yaFyaml package, but might indicate a bug
  in yaFyaml (or gFTL).

- Fixed non-standard-conforming mismatched integer KIND in deque implementation.

- Fixed misspelling of SUCCESS

## Removed

- Various unused local variables that were causing annoying compiler warnings.
