### PR TITLE
Fix some missing redefinitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if (COMMAND cmake_policy)
 endif (COMMAND cmake_policy)
 
 project (GFTL
-  VERSION 1.8.0
+  VERSION 1.8.1
   LANGUAGES NONE)
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [1.8.1] - 2022-06-15
+
+### Fixed
+
+- Fix some macro redefinitions in `v1/map.inc`
+
 ## [1.8.0] - 2022-05-31
 
 ## Changed

--- a/include/v1/templates/map.inc
+++ b/include/v1/templates/map.inc
@@ -153,6 +153,16 @@
 
 #include "templates/type_set_use_tokens.inc"
 
+#ifdef __USE_ASSIGN
+#  undef __USE_ASSIGN
+#endif
+#ifdef __USE_MOVE
+#  undef __USE_MOVE
+#endif
+#ifdef __USE_FREE
+#  undef __USE_FREE
+#endif
+
 #ifdef  __PAIR_ASSIGN
 #  define __USE_ASSIGN(dest,src) __PAIR_ASSIGN(dest,src)
 #else


### PR DESCRIPTION
Closes #180 

Testing with FORD found a few macros in v1 that weren't undef'd before redefining.

Note that I haven't tested this with GEOS, but it seems safe...