### PR TITLE
Add preliminary Intel LLVM Support

### DIFF
--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- Added `IntelLLVM.cmake` file as a copy of `Intel.cmake` to support the LLVM Intel compiler frontends
+
 ## [1.8.0] - 2022-05-31
 
-## Changed
+### Changed
 
 - Interfaces (intents) to map::at() and ordered_map::at().  The self object should be `INTENT(IN)` for these interfaces.
 
@@ -17,7 +21,7 @@
    - Added gfortran-11
    - Added gfortran-12 (for ubuntu-22.04)
 
-## Fixed
+### Fixed
 
 - Fixed bug in `vector::insert_range()` (needs a unit test)
 
@@ -28,7 +32,7 @@
 
 - Fixed misspelling of SUCCESS
 
-## Removed
+### Removed
 
 - Various unused local variables that were causing annoying compiler warnings.
 

--- a/cmake/IntelLLVM.cmake
+++ b/cmake/IntelLLVM.cmake
@@ -1,0 +1,27 @@
+# Compiler specific flags for Intel Fortran compiler
+
+if(WIN32)
+  set(no_optimize "-Od")
+  set(check_all "-check:all")
+  set(debug_info "-Zi")
+  set(save_temps "-Qsave-temps")
+  set(disable_warning_for_long_names "-Qdiag-disable:5462")
+  set(cpp "-fpp")
+else()
+  set(no_optimize "-O0")
+  set(check_all "-check all,noarg_temp_created")
+  set(debug_info "-g")
+  set(save_temps "-save-temps")
+  set(disable_warning_for_long_names "-diag-disable 5462")
+  set(cpp "-cpp")
+endif()
+  
+
+set(traceback "-traceback")
+
+
+set(CMAKE_Fortran_FLAGS_DEBUG  "${no_optimize} ${check_all} ${traceback} ${save_temps}")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_Fortran_FLAGS "${debug_info} ${cpp} ${traceback} ${check_all} ${disable_warning_for_long_names} ${save_temps}")
+
+add_definitions(-D_INTEL)


### PR DESCRIPTION
This PR adds preliminary `ifx` support by copying `cmake/Intel.cmake` to `cmake/IntelLLVM.cmake`. As noted by [Intel's porting guide](https://www.intel.com/content/www/us/en/developer/articles/guide/porting-guide-for-ifort-to-ifx.html), there are some flags changed or removed from `ifx` (compared to `ifort`), but they are usually a bit more advanced compared to flags used here.

One thing that might need to change is any macros (like `_INTEL`) as we might need different ones for `ifx`. There might also be workarounds/changes needed as seen in https://github.com/Goddard-Fortran-Ecosystem/pFUnit/pull/404

Keeping PR draft until `ifx` can be tested by us. 