### PR TITLE
Fixes #193 Fortran-friendly iterators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if (COMMAND cmake_policy)
 endif (COMMAND cmake_policy)
 
 project (GFTL
-  VERSION 1.8.2
+  VERSION 1.9.0
   LANGUAGES NONE)
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+## [1.9.0] - 2023-03-12
+
+### Added
+
+- Added Fortran-friendly iterator factories (and tests) to
+
+  `ftn_begin()` and `ftn_end()` have been added to vector, set, map,
+  and ordered_map templates.  `ftn_begin()` points to just-before the
+  1st element of a container, while `ftn_end()` points to the last
+  element.   This allows the `next()` invocation to be at the start of the loop which
+  is less error prone in the presence of `CYCLE` statements.   Example usage:
+  
+  ```f90
+  type(Vector) :: v
+  type(VectorIterator) :: iter
+  ...
+  associate (e => v%ftn_end())
+     iter = v%ftn_begin()
+     do while (iter /= e)
+        call iter%next()
+        ...
+        if (<cond>) cycle ! does the right thing
+        ...
+     end do
+  end associate
+  ```
+
 ## [1.8.2] - 2023-01-23
 
 ### Fixed

--- a/include/v2/map/iterator_procedures.inc
+++ b/include/v2/map/iterator_procedures.inc
@@ -148,6 +148,31 @@
       end function __MANGLE(iter_end)
 
 ! ======
+! ftn_begin
+! ======
+
+      function __MANGLE(iter_ftn_begin)(cont) result(begin)
+         type(__map_iterator) :: begin
+         type(__map), target, intent(in) :: cont
+
+         begin = cont%ftn_begin()
+
+         return
+      end function __MANGLE(iter_ftn_begin)
+
+! =====
+! ftn_end
+! =====
+
+      function __MANGLE(iter_ftn_end)(cont) result(end)
+         type(__map_iterator) :: end
+         type(__map), target, intent(in) :: cont
+
+         end = cont%ftn_end()
+
+         return
+      end function __MANGLE(iter_ftn_end)
+! ======
 ! next
 ! ======
 

--- a/include/v2/map/iterator_specification.inc
+++ b/include/v2/map/iterator_specification.inc
@@ -41,6 +41,14 @@
       module procedure __MANGLE(iter_end)
    end interface end
 
+   interface ftn_begin
+      module procedure __MANGLE(iter_ftn_begin)
+   end interface ftn_begin
+
+   interface ftn_end
+      module procedure __MANGLE(iter_ftn_end)
+   end interface ftn_end
+
    interface next
       module procedure __MANGLE(iter_next_1)
 #ifndef  __gftl_disable_index_kind_overload

--- a/include/v2/map/procedures.inc
+++ b/include/v2/map/procedures.inc
@@ -341,9 +341,9 @@
       end function __MANGLE(begin)
 
 
-! =======================
-!  end
-! =======================
+      ! =======================
+      !  end
+      ! =======================
       function __MANGLE(end)(this) result(iter)
          class(__map), target, intent(in) :: this
          type (__map_iterator) :: iter
@@ -352,6 +352,32 @@
          iter%set_iter = this%tree%end()
 
       end function __MANGLE(end)
+
+
+      ! =======================
+      !  ftn_begin
+      ! =======================
+      function __MANGLE(ftn_begin)(this) result(iter)
+         class(__map), target, intent(in) :: this
+         type (__map_iterator) :: iter
+
+         iter%reference => this
+         iter%set_iter = this%tree%ftn_begin()
+
+      end function __MANGLE(ftn_begin)
+
+
+      ! =======================
+      !  ftn_end
+      ! =======================
+      function __MANGLE(ftn_end)(this) result(iter)
+         class(__map), target, intent(in) :: this
+         type (__map_iterator) :: iter
+
+         iter%reference => this
+         iter%set_iter = this%tree%ftn_end()
+
+      end function __MANGLE(ftn_end)
 
 
 ! =======================

--- a/include/v2/map/public.inc
+++ b/include/v2/map/public.inc
@@ -10,6 +10,8 @@
    public :: advance
    public :: begin
    public :: end
+   public :: ftn_begin
+   public :: ftn_end
    public :: next
    public :: prev
 

--- a/include/v2/map/specification.inc
+++ b/include/v2/map/specification.inc
@@ -96,6 +96,8 @@
 
       procedure :: begin => __MANGLE(begin)
       procedure :: end => __MANGLE(end)
+      procedure :: ftn_begin => __MANGLE(ftn_begin)
+      procedure :: ftn_end => __MANGLE(ftn_end)
       procedure :: find => __MANGLE(find)
 
       procedure :: count => __MANGLE(count)

--- a/include/v2/ordered_map/iterator_procedures.inc
+++ b/include/v2/ordered_map/iterator_procedures.inc
@@ -161,6 +161,32 @@
       end function __MANGLE(iter_end)
 
 ! ======
+! ftn_begin
+! ======
+
+      function __MANGLE(iter_ftn_begin)(cont) result(begin)
+         type(__omap_iterator) :: begin
+         type(__omap), target, intent(in) :: cont
+
+         begin = cont%ftn_begin()
+
+         return
+      end function __MANGLE(iter_ftn_begin)
+
+! =====
+! ftn_end
+! =====
+
+      function __MANGLE(iter_ftn_end)(cont) result(end)
+         type(__omap_iterator) :: end
+         type(__omap), target, intent(in) :: cont
+
+         end = cont%ftn_end()
+
+         return
+      end function __MANGLE(iter_ftn_end)
+
+! ======
 ! next
 ! ======
 

--- a/include/v2/ordered_map/iterator_specification.inc
+++ b/include/v2/ordered_map/iterator_specification.inc
@@ -34,6 +34,14 @@
       module procedure __MANGLE(iter_end)
    end interface end
 
+   interface ftn_begin
+      module procedure __MANGLE(iter_ftn_begin)
+   end interface ftn_begin
+
+   interface ftn_end
+      module procedure __MANGLE(iter_ftn_end)
+   end interface ftn_end
+
    interface next
       module procedure __MANGLE(iter_next_1)
 #ifndef  __gftl_disable_index_kind_overload

--- a/include/v2/ordered_map/procedures.inc
+++ b/include/v2/ordered_map/procedures.inc
@@ -40,12 +40,14 @@
 #define __vector_guard __IDENTITY(__omap_guard)__IDENTITY(K_)
 #define __vector __IDENTITY(__omap_guard)__IDENTITY(Vector)
 #define __vector_iterator __IDENTITY(__omap_guard)__IDENTITY(VectorIterator)
+#define __vector_ftn_iterator __IDENTITY(__omap_guard)__IDENTITY(VectorFtnIterator)
 #define __vector_riterator __IDENTITY(__omap_guard)__IDENTITY(VectorRIterator)
 
 #include "vector/procedures.inc"
 
 #undef __vector
 #undef __vector_iterator
+#undef __vector_ftn_iterator
 #undef __vector_riterator
 #undef __vector_guard
 #include "parameters/T/undef_vector_T.inc"
@@ -334,6 +336,31 @@
          iter%key_iter = this%ordered_keys%end()
 
       end function __MANGLE(end)
+
+! =======================
+!  ftn_begin
+! =======================
+      function __MANGLE(ftn_begin)(this) result(iter)
+         class(__omap), target, intent(in) :: this
+         type (__omap_iterator) :: iter
+
+         iter%reference => this
+         iter%key_iter = this%ordered_keys%ftn_begin()
+
+      end function __MANGLE(ftn_begin)
+
+
+! =======================
+!  ftn_end
+! =======================
+      function __MANGLE(ftn_end)(this) result(iter)
+         class(__omap), target, intent(in) :: this
+         type (__omap_iterator) :: iter
+
+         iter%reference => this
+         iter%key_iter = this%ordered_keys%ftn_end()
+
+      end function __MANGLE(ftn_end)
 
 
 ! =======================

--- a/include/v2/ordered_map/public.inc
+++ b/include/v2/ordered_map/public.inc
@@ -11,6 +11,8 @@
    public :: advance
    public :: begin
    public :: end
+   public :: ftn_begin
+   public :: ftn_end
    public :: next
    public :: prev
 

--- a/include/v2/ordered_map/specification.inc
+++ b/include/v2/ordered_map/specification.inc
@@ -41,12 +41,14 @@
 #define __vector_guard __IDENTITY(__omap_guard)__IDENTITY(K_)
 #define __vector __IDENTITY(__omap_guard)__IDENTITY(Vector)
 #define __vector_iterator __IDENTITY(__omap_guard)__IDENTITY(VectorIterator)
+#define __vector_ftn_iterator __IDENTITY(__omap_guard)__IDENTITY(VectorFtnIterator)
 #define __vector_riterator __IDENTITY(__omap_guard)__IDENTITY(VectorRIterator)
 
 #include "vector/specification.inc"
 
 #undef __vector
 #undef __vector_iterator
+#undef __vector_ftn_iterator
 #undef __vector_riterator
 #undef __vector_guard
 #include "parameters/T/undef_vector_T.inc"
@@ -100,6 +102,8 @@
 
       procedure :: begin => __MANGLE(begin)
       procedure :: end => __MANGLE(end)
+      procedure :: ftn_begin => __MANGLE(ftn_begin)
+      procedure :: ftn_end => __MANGLE(ftn_end)
       procedure :: find => __MANGLE(find)
 
       procedure :: count => __MANGLE(count)

--- a/include/v2/set/iterator_procedures.inc
+++ b/include/v2/set/iterator_procedures.inc
@@ -106,6 +106,26 @@
    end function __MANGLE(iter_end)
    
 
+   function __MANGLE(iter_ftn_begin)(cont) result(begin)
+      type(__set_iterator) :: begin
+      type(__set), target, intent(in) :: cont
+      
+      begin = cont%ftn_begin()
+      
+      return
+   end function __MANGLE(iter_ftn_begin)
+   
+   
+   
+   function __MANGLE(iter_ftn_end)(cont) result(end)
+      type(__set_iterator) :: end
+      type(__set), target, intent(in) :: cont
+
+      end = cont%ftn_end()
+      
+   end function __MANGLE(iter_ftn_end)
+   
+
    function __MANGLE(iter_next_1)(it) result(new_it)
       type(__set_iterator) :: new_it
       type(__set_iterator), intent(in) :: it

--- a/include/v2/set/iterator_specification.inc
+++ b/include/v2/set/iterator_specification.inc
@@ -33,6 +33,14 @@
       module procedure __MANGLE(iter_end)
    end interface end
 
+   interface ftn_begin
+      module procedure __MANGLE(iter_ftn_begin)
+   end interface ftn_begin
+
+   interface ftn_end
+      module procedure __MANGLE(iter_ftn_end)
+   end interface ftn_end
+
    interface next
       module procedure __MANGLE(iter_next_1)
 #ifndef  __gftl_disable_index_kind_overload

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -448,6 +448,33 @@
  end function __MANGLE(end)
 
  ! =======================
+ !  ftn_begin
+ ! =======================
+ function __MANGLE(ftn_begin)(this) result(begin)
+    class(__set), target, intent(in) :: this
+    type(__set_iterator) :: begin
+
+    begin%tree => this
+
+    return
+ end function __MANGLE(ftn_begin)
+
+ ! =======================
+ !  end
+ ! =======================
+ function __MANGLE(ftn_end)(this) result(end_)
+    class(__set), target, intent(in) :: this
+    type(__set_iterator) :: end_
+
+    type(__set_iterator) :: tmp
+
+    ! brute force implementation for now
+    end_ = next(this%begin(), this%size()-1)
+
+    return
+ end function __MANGLE(ftn_end)
+
+ ! =======================
  !  lower_bound
  ! =======================
  function __MANGLE(lower_bound)(this, value) result(lb)

--- a/include/v2/set/public.inc
+++ b/include/v2/set/public.inc
@@ -10,6 +10,8 @@
    public :: advance
    public :: begin
    public :: end
+   public :: ftn_begin
+   public :: ftn_end
    public :: next
    public :: prev
 

--- a/include/v2/set/specification.inc
+++ b/include/v2/set/specification.inc
@@ -62,6 +62,8 @@
       generic :: erase => erase_iter, erase_value, erase_range
       procedure :: begin => __MANGLE(begin)
       procedure :: end => __MANGLE(end)
+      procedure :: ftn_begin => __MANGLE(ftn_begin)
+      procedure :: ftn_end => __MANGLE(ftn_end)
       procedure :: lower_bound => __MANGLE(lower_bound)
       procedure :: upper_bound => __MANGLE(upper_bound)
 

--- a/include/v2/vector/iterator_procedures.inc
+++ b/include/v2/vector/iterator_procedures.inc
@@ -226,6 +226,16 @@
       end function __MANGLE(iter_begin)
 
       
+      function __MANGLE(iter_ftn_begin)(cont) result(begin)
+         type(__vector_iterator) :: begin
+         type(__vector), target, intent(in) :: cont
+
+         begin = cont%begin()
+
+         return
+      end function __MANGLE(iter_ftn_begin)
+
+      
       integer(kind=__gftl_size_kind) function __MANGLE(iter_distance)(a, b) result(distance)
          class(__vector_iterator), intent(in) :: a
          type(__vector_iterator), intent(in) :: b
@@ -244,6 +254,16 @@
 
          return
       end function __MANGLE(iter_end)
+
+
+      function __MANGLE(iter_ftn_end)(cont) result(end)
+         type(__vector_iterator) :: end
+         type(__vector), target, intent(in) :: cont
+
+         end = cont%ftn_end()
+
+         return
+      end function __MANGLE(iter_ftn_end)
 
 
       function __MANGLE(iter_next_1)(it) result(new_it)

--- a/include/v2/vector/iterator_specification.inc
+++ b/include/v2/vector/iterator_specification.inc
@@ -110,6 +110,10 @@
       module procedure __MANGLE(iter_begin)
    end interface begin
 
+   interface ftn_begin
+      module procedure __MANGLE(iter_ftn_begin)
+   end interface ftn_begin
+
    interface distance
       module procedure __MANGLE(iter_distance)
    end interface distance
@@ -117,6 +121,10 @@
    interface end
       module procedure __MANGLE(iter_end)
    end interface end
+
+   interface ftn_end
+      module procedure __MANGLE(iter_ftn_end)
+   end interface ftn_end
 
    interface next
       ! Cannot use optional dummy due to otherwise ambiguous interfaces

--- a/include/v2/vector/procedures.inc
+++ b/include/v2/vector/procedures.inc
@@ -930,6 +930,23 @@
 
    end function __MANGLE(begin)
 
+   ! ==============================
+   !  ftn_begin() - create an iterator with fortran looping convention
+   ! ==============================
+   function __MANGLE(ftn_begin)(this) result(iter)
+      type (__vector_iterator) :: iter
+      class (__vector), target, intent(in) :: this
+
+      iter%current_index = 0
+
+      if (allocated(this%elements)) then
+         iter%elements => this%elements
+      else
+         iter%elements => null()
+      end if
+
+   end function __MANGLE(ftn_begin)
+
 
    ! =======================
    !  end()
@@ -948,6 +965,24 @@
       end if
 
    end function __MANGLE(end)
+
+   ! =======================
+   !  ftn_end()
+   !  Construct  forward iterator, initially set to
+   !  last element of vector.
+   ! =======================
+   function __MANGLE(ftn_end)(this) result(iter)
+      class (__vector), target, intent(in) :: this
+      type (__vector_iterator) :: iter
+
+      iter%current_index = this%size() ! end
+      if (allocated(this%elements)) then
+         iter%elements => this%elements
+      else
+         iter%elements => null()
+      end if
+
+   end function __MANGLE(ftn_end)
 
 
    ! =======================

--- a/include/v2/vector/public.inc
+++ b/include/v2/vector/public.inc
@@ -9,8 +9,10 @@
    ! Iterator functions
    public :: advance
    public :: begin
+   public :: ftn_begin
    public :: distance
    public :: end
+   public :: ftn_end
    public :: next
    public :: prev
    public :: operator(+)

--- a/include/v2/vector/specification.inc
+++ b/include/v2/vector/specification.inc
@@ -147,6 +147,8 @@
       ! Factory methods for iterators
       procedure :: begin => __MANGLE(begin)
       procedure :: end => __MANGLE(end)
+      procedure :: ftn_begin => __MANGLE(ftn_begin)
+      procedure :: ftn_end => __MANGLE(ftn_end)
       procedure :: rbegin => __MANGLE(rbegin)
       procedure :: rend => __MANGLE(rend)
 

--- a/include/v2/vector/tail.inc
+++ b/include/v2/vector/tail.inc
@@ -4,12 +4,15 @@
 #ifdef __vector
 #    undef __vector
 #endif
+
 #ifdef __vector_iterator
 #    undef __vector_iterator
 #endif
+
 #ifdef __vector_riterator
 #    undef __vector_riterator
 #endif
+
 #ifdef __vector_guard
 #    undef __vector_guard
 #endif

--- a/tests/map/Test_Map.m4
+++ b/tests/map/Test_Map.m4
@@ -323,6 +323,20 @@ contains
    end subroutine test_make_from_array_of_pairs
 #endif
 
+   @test
+   subroutine test_ftn_iter()
+      type(Map), target :: m
+
+      call m%insert(key_one, one)
+      call m%insert(key_two, two)
+
+      @assert_that('ftn_begin', next(m%ftn_begin()) == m%begin(), is(true()))
+      @assert_that('ftn_end', next(m%ftn_end()) == m%end(), is(true()))
+
+   end subroutine test_ftn_iter
+
+
+
 #include "parameters/Key/undef_derived_macros.inc"
 #include "parameters/Key/undef_internal.inc"
 #include "parameters/Key/undef_map_Key.inc"

--- a/tests/ordered_map/Test_OrderedMap.m4
+++ b/tests/ordered_map/Test_OrderedMap.m4
@@ -361,6 +361,19 @@ contains
    end subroutine test_make_from_array_of_pairs
 #endif
 
+   @test
+   subroutine test_ftn_iter()
+      type(OrderedMap), target :: m
+
+      call m%insert(key_one, one)
+      call m%insert(key_two, two)
+
+      @assert_that('ftn_begin', next(m%ftn_begin()) == m%begin(), is(true()))
+      @assert_that('ftn_end', next(m%ftn_end()) == m%end(), is(true()))
+
+   end subroutine test_ftn_iter
+
+
 #include "parameters/Key/undef_derived_macros.inc"
 #include "parameters/Key/undef_internal.inc"
 #include "parameters/Key/undef_map_Key.inc"

--- a/tests/set/Test_Set.m4
+++ b/tests/set/Test_Set.m4
@@ -229,6 +229,20 @@ contains
    end subroutine test_swap
 
 
+   @test
+   subroutine test_ftn_iter()
+      type(set), target :: s
+
+      call s%insert(one)
+      call s%insert(two)
+      call s%insert(three)
+
+      @assert_that('ftn_begin', next(s%ftn_begin()) == s%begin(), is(true()))
+      @assert_that('ftn_end', next(s%ftn_end()) == s%end(), is(true()))
+
+   end subroutine test_ftn_iter
+
+
 #include "parameters/T/undef_derived_macros.inc"
 #include "parameters/T/undef_internal.inc"
 #include "parameters/T/undef_set_T.inc"

--- a/tests/vector/CMakeLists.txt
+++ b/tests/vector/CMakeLists.txt
@@ -32,7 +32,8 @@ foreach (T ${types})
 
   add_pfunit_ctest (${test}.x
     TEST_SOURCES ${bin}/${test}.pf
-                 ${bin}/${test}Iterator.pf ${bin}/${test}RIterator.pf
+                 ${bin}/${test}Iterator.pf
+                 ${bin}/${test}RIterator.pf
                  ${bin}/${test}Algorithms.pf
     OTHER_SOURCES ${sut}
     LINK_LIBRARIES test_shared gftl-v2

--- a/tests/vector/Test_VectorIterator.m4
+++ b/tests/vector/Test_VectorIterator.m4
@@ -316,6 +316,66 @@ contains
       
    end subroutine test_prev
 
+
+   @test
+   subroutine test_compare_ftn_iter()
+      type(Vector) :: v
+      type(VectorIterator) :: iter
+
+      call v%push_back(one)
+      call v%push_back(two)
+
+      @assert_that(next(v%ftn_begin(),1) == v%begin(), is(true()))
+      @assert_that(next(v%ftn_begin(),2) == next(v%begin(),1), is(true()))
+
+      @assert_that(v%ftn_end() == prev(v%end(),1), is(true()))
+      @assert_that(prev(v%ftn_end(),1) == prev(v%end(),2), is(true()))
+      
+   end subroutine test_compare_ftn_iter
+
+   @test
+   subroutine test_ftn_next()
+      type(Vector) :: v
+      type(VectorIterator) :: iter
+
+      call v%push_back(one)
+      call v%push_back(two)
+
+      iter = next(v%ftn_begin(),1)
+      ASSERT(iter%of(), one)
+
+      iter = next(v%ftn_begin(),2)
+      @assert_that(iter == v%ftn_end(), is(true()))
+
+      iter = next(v%ftn_begin(),1_GFTL_SIZE_KIND)
+      ASSERT(iter%of(), one)
+
+      iter = next(v%ftn_begin(),2_GFTL_SIZE_KIND)
+      @assert_that(iter == v%ftn_end(), is(true()))
+
+   end subroutine test_ftn_next
+
+   @test
+   subroutine test_ftn_prev()
+      type(Vector) :: v
+      type(VectorIterator) :: iter
+
+      call v%push_back(one)
+      call v%push_back(two)
+      call v%push_back(three)
+
+      iter = prev(v%ftn_end(),1)
+      ASSERT(iter%of(), two)
+      iter = prev(v%ftn_end(),2)
+      ASSERT(iter%of(), one)
+      
+      iter = prev(v%ftn_end(),1_GFTL_SIZE_KIND)
+      ASSERT(iter%of(), two)
+      iter = prev(v%ftn_end(),2_GFTL_SIZE_KIND)
+      ASSERT(iter%of(), one)
+      
+   end subroutine test_ftn_prev
+
 #include "parameters/T/undef_derived_macros.inc"
 #include "parameters/T/undef_internal.inc"
 #include "parameters/T/undef_vector_T.inc"


### PR DESCRIPTION
- Added Fortran-friendly iterator factories (and tests) to

  `ftn_begin()` and `ftn_end()` have been added to vector, set, map, and ordered_map templates.  `ftn_begin()` points to just-before the 1st element of a container, while `ftn_end()` points to the last
  element.   This allows the `next()` invocation to be at the start of the loop which
  is less error prone in the presence of `CYCLE` statements.   Example usage:

  ```f90 type(Vector) :: v type(VectorIterator) :: iter ... associate (e => v%ftn_end()) iter = v%ftn_begin() do while (iter /= e) call iter%next() ... if (<cond>) cycle ! does the right thing ... end do end associate ```