### PR TITLE
skip move_alloc in vector and deque erase_range with empty iterator

### DIFF
--- a/include/v2/deque/procedures.inc
+++ b/include/v2/deque/procedures.inc
@@ -735,22 +735,24 @@
       integer(kind=GFTL_SIZE_KIND) :: i, ii, delta
 
       delta=last%current_index-first%current_index
-      do i=last%current_index, this%size_
-         ii = this%idx(i)
-         associate( &
-              a => this%buckets(ii-delta)%ptr%bucket_items, &
-              b => this%buckets(ii)%ptr%bucket_items)
-              __T_MOVE__(a%item, b%item)
-         end associate
-      end do
-      do i = this%size_ - delta + 1, last%current_index - 1
-         ii = this%idx(i)
-         __T_FREE__(this%buckets(ii)%ptr%bucket_items%item)
-      end do
-      this%size_=this%size_-delta
+      if (delta.gt.0) then
+        do i=last%current_index, this%size_
+           ii = this%idx(i)
+           associate( &
+                a => this%buckets(ii-delta)%ptr%bucket_items, &
+                b => this%buckets(ii)%ptr%bucket_items)
+                __T_MOVE__(a%item, b%item)
+           end associate
+        end do
+        do i = this%size_ - delta + 1, last%current_index - 1
+           ii = this%idx(i)
+           __T_FREE__(this%buckets(ii)%ptr%bucket_items%item)
+        end do
+        this%size_=this%size_-delta
 
-      ! back may wrap around
-      this%back_ = 1 + modulo(this%back_ - delta - 1, this%size_)
+        ! back may wrap around
+        this%back_ = 1 + modulo(this%back_ - delta - 1, this%size_)
+      end if
 
       new_iter%deque => this
       new_iter%current_index = first%current_index

--- a/include/v2/vector/procedures.inc
+++ b/include/v2/vector/procedures.inc
@@ -772,15 +772,17 @@
       integer(kind=GFTL_SIZE_KIND) :: i, delta
 
       delta=last%current_index-first%current_index
-      do i=last%current_index, this%vsize
-         associate(a => this%elements(i-delta),b =>this%elements(i))
-           __T_MOVE__(a%item, b%item)
-         end associate
-      end do
-      do i = this%vsize - delta + 1, last%current_index - 1
-         __T_FREE__(this%elements(i)%item)
-      end do
-      this%vsize=this%vsize-delta
+      if (delta.gt.0) then
+        do i=last%current_index, this%vsize
+           associate(a => this%elements(i-delta),b =>this%elements(i))
+             __T_MOVE__(a%item, b%item)
+           end associate
+        end do
+        do i = this%vsize - delta + 1, last%current_index - 1
+           __T_FREE__(this%elements(i)%item)
+        end do
+        this%vsize=this%vsize-delta
+      end if
 
       new_iter%elements => this%elements
       new_iter%current_index = first%current_index

--- a/tests/vector/Test_Vector.m4
+++ b/tests/vector/Test_Vector.m4
@@ -410,6 +410,10 @@ contains
 
       @assert_that(int(v%size()), is(4))
       @assert_that(next_iter == iter, is(true()))
+      ASSERT(v%at(1), one)
+      ASSERT(v%at(2), two)
+      ASSERT(v%at(3), three)
+      ASSERT(v%at(4), one)
 
    end subroutine test_erase_empty_range
 


### PR DESCRIPTION
The current code was calling MOVE_ALLOC(X, X) on all elements after the empty
iterator. Most compilers do not emit runtime error, but this is not legal
Fortran (see below), and the effect of most compilers is to deallocate X, which
is likely not the intention of erase_range(iterator, iterator) that I would
expect to be a no-op. Instead, most compilers will compile it into code that
silently destroy all the vector elements after the iterator (but keep the
vector size unchanged).

The updated tests (first commit) without the erase_range code change (second
commit) fails with gfortran (see below).

This patch updates erase_range code to do nothing when the delta is not strictly
positive (in both case I do not think the code is meant to deal with reversed iterators,
please correct me if you think only the delta == 0 case should bypass the code).


**Standard Reference:**

Fortran 2018 section 16.9.137 point 4 mandates regarding MOVE_ALLOC(TO, FROM):
"if FROM and TO are the same variable, it shall be unallocated when MOVE_ALLOC
is invoked"


**gfortran crash with the updated test (without the fix):**

```
	 23 - Test_deferred_stringVector.x (Failed)
	 24 - Test_unlimitedVector.x (SEGFAULT)
	 26 - Test_real_rank_2_deferred_shapeVector.x (SEGFAULT)
	 28 - Test_FooPolyVector.x (SEGFAULT)
	 29 - Test_AbstractBarVector.x (SEGFAULT)
```

Test_deferred_stringVector.x log:
```
[Test_deferred_stringVector.pf:851]
String assertion failed:
    expected: <"">
   but found: <"two">
  first diff: 
```

Note: my patch is not motivated by an apps using erase_range on an empty range. It is motivated by the fact that flang emits a runtime error for such MOVE_ALLOC and therefore failed the test. If you think that calling erase_range on an empty range should not be allowed, maybe the test can also be removed. And maybe destroying the elements is the intention here, and then we will need an extension in flang to silence the runtime error.