### PR TITLE
Fixes #211 - degenerate erase() bug

### DIFF
--- a/include/v2/deque/procedures.inc
+++ b/include/v2/deque/procedures.inc
@@ -735,6 +735,10 @@
       integer(kind=GFTL_SIZE_KIND) :: i, ii, delta
 
       delta=last%current_index-first%current_index
+      if (delta == 0) then
+         new_iter = last
+         return
+      end if
       do i=last%current_index, this%size_
          ii = this%idx(i)
          associate( &

--- a/include/v2/vector/procedures.inc
+++ b/include/v2/vector/procedures.inc
@@ -772,6 +772,11 @@
       integer(kind=GFTL_SIZE_KIND) :: i, delta
 
       delta=last%current_index-first%current_index
+      if (delta == 0) then
+         new_iter = last
+         return
+      end if
+
       do i=last%current_index, this%vsize
          associate(a => this%elements(i-delta),b =>this%elements(i))
            __T_MOVE__(a%item, b%item)


### PR DESCRIPTION
The previous logic in some containers resulted in incorrect operations happening when first==last.  Effectively, the code would try to copy element x onto itself.  This was ok albeit inefficient for the non allocatable cases.  However, for the allocatable case I had `move_alloc(x, x)` which is erronous Fortran.