### PR TITLE
Add quiet flag for NAG Fortran

### DIFF
--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+
+- Added `-quiet` flag for NAG compiler
 
 ## [1.12.0] - 2024-03-03
 

--- a/cmake/NAG.cmake
+++ b/cmake/NAG.cmake
@@ -5,6 +5,6 @@ set (check_all "-C=all -nocheck_modtime")
 set (cpp "-fpp")
 set (suppress_fpp_warnings "-w")
 
-set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g ${cpp} -nocheck_modtime -w=x95")
+set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -quiet ${cpp} -nocheck_modtime -w=x95")
 set (CMAKE_Fortran_FLAGS_DEBUG  "${CMAKE_Fortran_FLAGS} ${no_optimize} ${traceback} ${check_all}")
 set (CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS} -O3")


### PR DESCRIPTION
This PR adds `-quiet` to the NAG Fortran compiler flags. This flag will "[s]uppress the compiler banner and the summary line, so that only diagnostic messages will appear."