### PR TITLE
Update CI - 2024-Aug-22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
         compiler: [gfortran-12, gfortran-13, gfortran-14]
         # gfortran-10 and -11 are only on ubuntu-22.04
-        # gfortran-13 and -13 are not on ubuntu-22.04
+        # gfortran-13 and -14 are not on ubuntu-22.04
         include:
           - os: ubuntu-22.04
             compiler: gfortran-10

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,19 +16,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
-        compiler: [gfortran-11, gfortran-12, gfortran-13]
-        # gfortran-10 is only on ubuntu-22.04
-        # gfortran-14 is available on ubuntu-24.04
+        compiler: [gfortran-12, gfortran-13, gfortran-14]
+        # gfortran-10 and -11 are only on ubuntu-22.04
+        # gfortran-13 and -13 are not on ubuntu-22.04
         include:
           - os: ubuntu-22.04
             compiler: gfortran-10
-          - os: ubuntu-24.04
-            compiler: gfortran-14
-        exclude:
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             compiler: gfortran-11
+        exclude:
           - os: ubuntu-22.04
             compiler: gfortran-13
+          - os: ubuntu-22.04
+            compiler: gfortran-14
 
       # fail-fast if set to 'true' here is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails
@@ -93,7 +93,7 @@ jobs:
             build/**/*.log
 
   Intel:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       FC: ifx
@@ -169,8 +169,8 @@ jobs:
             build/**/*.log
 
   Nvidia:
-    runs-on: ubuntu-20.04
-    container: nvcr.io/nvidia/nvhpc:24.1-devel-cuda12.3-ubuntu22.04
+    runs-on: ubuntu-22.04
+    container: nvcr.io/nvidia/nvhpc:24.7-devel-cuda12.5-ubuntu22.04
     env:
       FC: nvfortran
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -246,7 +246,7 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
 
-      - name: Add additional packages
+      - name: Add python-is-python3 package
         run: |
           apt-get update
           apt-get install -y python-is-python3

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- Update CI to have `gfortran-10` and `gfortran-11` only on `ubuntu-20.04`
+- Update CI to have `gfortran-10` and `gfortran-11` only on `ubuntu-22.04`
 - Update CI NVIDIA to NVHPC 24.7
 
 ## [1.14.0] - 2024-07-09

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -6,6 +6,11 @@
 
 - Preliminary LLVMFlang support
 
+### Changed
+
+- Update CI to have `gfortran-10` and `gfortran-11` only on `ubuntu-20.04`
+- Update CI NVIDIA to NVHPC 24.7
+
 ## [1.14.0] - 2024-07-09
 
 ### Fixed


### PR DESCRIPTION
This PR updates the CI to remove `gfortran-11` from the general matrix. Now only `ubuntu-22.04` supports `gfortran-10` and `gfortran-11`. The other images only support `gfortran-12` and higher. Moreover, `ubuntu-22.04` does not support `gfortran-13` and `gfortran-14`.

We also update the NVIDIA CI image to 24.7

We also add a Flang test.