### PR TITLE
Update CMake minimum version to 3.24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
         compiler: [gfortran-12, gfortran-13, gfortran-14]
         # gfortran-10 and -11 are only on ubuntu-22.04
         # gfortran-13 and -14 are not on ubuntu-22.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,19 +14,7 @@ if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif ()
 
 # For BSD systems use GNU m4
-find_program( M4 NAMES "gm4" "m4" PATHS "${CMAKE_CURRENT_BINARY_DIR}/m4/bin")
-if( NOT M4 )
-  if( WIN32 )
-    message( STATUS "Downloading M4 program from SourceForge")
-    file(DOWNLOAD "https://downloads.sourceforge.net/gnuwin32/m4-1.4.14-1-bin.zip" "${CMAKE_CURRENT_BINARY_DIR}/m4-bin.zip" )
-    file(DOWNLOAD "http://downloads.sourceforge.net/gnuwin32/m4-1.4.14-1-dep.zip" "${CMAKE_CURRENT_BINARY_DIR}/m4-dep.zip" )
-    file(ARCHIVE_EXTRACT INPUT "${CMAKE_CURRENT_BINARY_DIR}/m4-bin.zip" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/m4" PATTERNS "bin")
-    file(ARCHIVE_EXTRACT INPUT "${CMAKE_CURRENT_BINARY_DIR}/m4-dep.zip" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/m4" PATTERNS "bin")
-    set(M4 "${CMAKE_CURRENT_BINARY_DIR}/m4/bin/m4.exe")
-  else ()
-    message( SEND_ERROR "m4 program not found" )
-  endif()
-endif()
+find_program( M4 NAMES gm4 m4 m4.exe REQUIRED )
 
 # Some preprocessing tests can be run without the
 # Fortran testing framework.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.24)
 if (COMMAND cmake_policy)
   cmake_policy (SET CMP0003 NEW)
 endif (COMMAND cmake_policy)
 
 project (GFTL
-  VERSION 1.15.2
+  VERSION 1.16.0
   LANGUAGES NONE)
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -4,9 +4,15 @@
 
 ## [1.16.0] - 2025-04-16
 
+### Removed
+
+- Removed download of `m4` on Windows if not found. We now require the user to provide it
+- Removed `filter.x.in` for pure Awk in CMake `custom_command`
+
 ### Changed
 
 - Updated CMake minimum version to 3.24
+- Made `awk` and `m4` `REQUIRED` via `find_program`
 
 ## [1.15.2] - 2025-02-10
 

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [1.16.0] - 2025-04-16
+
+### Changed
+
+- Updated CMake minimum version to 3.24
+
 ## [1.15.2] - 2025-02-10
 
 ### Fixed

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -13,6 +13,7 @@
 
 - Updated CMake minimum version to 3.24
 - Made `awk` and `m4` `REQUIRED` via `find_program`
+- Update CI to use `macos-15`, remove `macos-13`
 
 ## [1.15.2] - 2025-02-10
 

--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -7,6 +7,7 @@
 ### Changed
 
 - Updated CMake minimum version to 3.24
+- Update CI to use `macos-15`, remove `macos-13`
 
 ## [1.15.2] - 2025-02-10
 

--- a/examples/v1/CMakeLists.txt
+++ b/examples/v1/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -assume realloc_lhs")
 endif()

--- a/examples/v1/CMakeLists.txt
+++ b/examples/v1/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.24)
 if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -assume realloc_lhs")
 endif()

--- a/examples/v1/Map/CMakeLists.txt
+++ b/examples/v1/Map/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 
 include_directories("$ENV{FTL}/include")
 add_executable(CIKey.x CaseInsensitiveKey.F90)

--- a/examples/v1/Map/CMakeLists.txt
+++ b/examples/v1/Map/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.24)
-
 include_directories("$ENV{FTL}/include")
 add_executable(CIKey.x CaseInsensitiveKey.F90)
 add_executable(StringPoly.x StringPoly.F90)

--- a/examples/v1/Tracer/CMakeLists.txt
+++ b/examples/v1/Tracer/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.24)
-
 include_directories("$ENV{FTL}/include")
 link_directories("$ENV{MODELE}/modelEMaster/model/shared")
 link_directories("$ENV{MODELE}/modelEMaster/model/MPI_Support")

--- a/examples/v1/Tracer/CMakeLists.txt
+++ b/examples/v1/Tracer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 
 include_directories("$ENV{FTL}/include")
 link_directories("$ENV{MODELE}/modelEMaster/model/shared")

--- a/examples/v1/Vector/CMakeLists.txt
+++ b/examples/v1/Vector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 
 include_directories("$ENV{FTL}/include")
 #add_executable(VecIntAndReal.x EXCLUDE_FROM_ALL VecIntAndReal.F90)

--- a/examples/v1/Vector/CMakeLists.txt
+++ b/examples/v1/Vector/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.24)
-
 include_directories("$ENV{FTL}/include")
 #add_executable(VecIntAndReal.x EXCLUDE_FROM_ALL VecIntAndReal.F90)
 #add_executable(VecMyType.x EXCLUDE_FROM_ALL VecMyType.F90)

--- a/examples/v2/Vector/CMakeLists.txt
+++ b/examples/v2/Vector/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.24)
-
 project(VectorExamples Fortran)
 
 find_package(GFTL REQUIRED)

--- a/examples/v2/Vector/CMakeLists.txt
+++ b/examples/v2/Vector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 
 project(VectorExamples Fortran)
 

--- a/include/v1/CMakeLists.txt
+++ b/include/v1/CMakeLists.txt
@@ -12,11 +12,6 @@ target_include_directories (gftl-v1 INTERFACE
   $<INSTALL_INTERFACE:${dest}/include/v1>           # for client in install mode
   )
 
-find_program (M4 m4)
-if( NOT M4 )
-  message( SEND_ERROR "m4 program not found" )
-endif()
-
 add_subdirectory (templates)
 add_subdirectory (types)
 

--- a/include/v2/CMakeLists.txt
+++ b/include/v2/CMakeLists.txt
@@ -18,11 +18,6 @@ set (template_parameters
   T2 # pair
   )
 
-find_program( M4 m4)
-if( NOT M4 )
-  message( SEND_ERROR "m4 program not found" )
-endif()
-
 add_subdirectory(shared)
 add_subdirectory(parameters)
 

--- a/include/v2/examples/CMakeLists.txt
+++ b/include/v2/examples/CMakeLists.txt
@@ -1,8 +1,3 @@
-find_program( M4 m4)
-if( NOT M4 )
-  message( SEND_ERROR "m4 program not found" )
-endif()
-
 set (base_types
 
   character

--- a/include/v2/generated/CMakeLists.txt
+++ b/include/v2/generated/CMakeLists.txt
@@ -3,11 +3,6 @@
 
 add_subdirectory(tests)
 
-find_program( M4 m4)
-if( NOT M4 )
-  message( SEND_ERROR "m4 program not found" )
-endif()
-
 set (m4_sources
   define_derived_macros.m4
   undef_derived_macros.m4

--- a/include/v2/parameters/CMakeLists.txt
+++ b/include/v2/parameters/CMakeLists.txt
@@ -1,11 +1,6 @@
 # This directory uses m4 to generate various CPP/FPP include files that
 # are used by gFTL templates.  
 
-find_program( M4 m4)
-if( NOT M4 )
-  message( SEND_ERROR "m4 program not found" )
-endif()
-
 function (process_m4 parameter input_file output_file)
 #  message("processing: ${input_file} and ${output_file}")
   add_custom_command (

--- a/include/v2/parameters/tests/CMakeLists.txt
+++ b/include/v2/parameters/tests/CMakeLists.txt
@@ -45,8 +45,8 @@ foreach(type ${types})
     OUTPUT ${actual}
     COMMAND ${CPP} -traditional -I${GFTL_SOURCE_DIR}/include/v2 -I${GFTL_BINARY_DIR}/include/v2 ${source} > ${tmp}
     # Strip all empty lines and comments
-    COMMAND ${AWK} "\"/<start>/,/<stop>/\"" ${tmp} > ${tmp2}
-    COMMAND ${AWK} "\"NR>2 {print last} {last=$$0}\"" ${tmp2} > ${actual}
+    COMMAND ${AWK} '/<start>/,/<stop>/' ${tmp} > ${tmp2}
+    COMMAND ${AWK} 'NR>2 {print last} {last=$$0}' ${tmp2} > ${actual}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS ${type}.inc m4_type_includes
     )

--- a/include/v2/parameters/tests/CMakeLists.txt
+++ b/include/v2/parameters/tests/CMakeLists.txt
@@ -42,22 +42,26 @@ foreach(type ${types})
   set (actual actual_${type}.txt)
 
   if(WIN32)
-    set(AWK_PROG1 "\"/<start>/,/<stop>/\"")
-    set(AWK_PROG2 "\"NR>2 {print last} {last=$$0}\"")
+    add_custom_command (
+      OUTPUT ${actual}
+      COMMAND ${CPP} -traditional -I${GFTL_SOURCE_DIR}/include/v2 -I${GFTL_BINARY_DIR}/include/v2 ${source} > ${tmp}
+      # Strip all empty lines and comments
+      COMMAND ${AWK} "\"/<start>/,/<stop>/\"" ${tmp} > ${tmp2}
+      COMMAND ${AWK} "\"NR>2 {print last} {last=$$0}\"" ${tmp2} > ${actual}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      DEPENDS ${type}.inc m4_type_includes
+      )
   else()
-    set(AWK_PROG1 "'/<start>/,/<stop>/'")
-    set(AWK_PROG2 "'NR>2 {print last} {last=$$0}'")
+    add_custom_command (
+      OUTPUT ${actual}
+      COMMAND ${CPP} -traditional -I${GFTL_SOURCE_DIR}/include/v2 -I${GFTL_BINARY_DIR}/include/v2 ${source} > ${tmp}
+      # Strip all empty lines and comments
+      COMMAND ${AWK} '/<start>/,/<stop>/' ${tmp} > ${tmp2}
+      COMMAND ${AWK} 'NR>2 {print last} {last=$$0}' ${tmp2} > ${actual}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      DEPENDS ${type}.inc m4_type_includes
+      )
   endif()
-
-  add_custom_command(
-    OUTPUT ${actual}
-    COMMAND ${CPP} -traditional -I${GFTL_SOURCE_DIR}/include/v2 -I${GFTL_BINARY_DIR}/include/v2 ${source} > ${tmp}
-    # Strip all empty lines and comments
-    COMMAND ${AWK} ${AWK_PROG1} ${tmp} > ${tmp2}
-    COMMAND ${AWK} ${AWK_PROG2} ${tmp2} > ${actual}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${type}.inc m4_type_includes
-  )
 
   list(APPEND actuals ${actual})
 

--- a/include/v2/parameters/tests/CMakeLists.txt
+++ b/include/v2/parameters/tests/CMakeLists.txt
@@ -30,9 +30,7 @@ set (types
   kitchen_sink
   )
 
-find_program(AWK awk)
-configure_file (filter.x.in filter.x @ONLY)
-find_program(FILTER filter.x ${CMAKE_CURRENT_BINARY_DIR})
+find_program(AWK NAMES gawk awk nawk awk.exe REQUIRED)
 
 set(actuals)
 foreach(type ${types})
@@ -45,9 +43,10 @@ foreach(type ${types})
 
   add_custom_command (
     OUTPUT ${actual}
-        COMMAND ${CPP} -traditional -I${GFTL_SOURCE_DIR}/include/v2 -I${GFTL_BINARY_DIR}/include/v2 ${source} > ${tmp}
+    COMMAND ${CPP} -traditional -I${GFTL_SOURCE_DIR}/include/v2 -I${GFTL_BINARY_DIR}/include/v2 ${source} > ${tmp}
     # Strip all empty lines and comments
-    COMMAND ${FILTER} ${tmp} ${actual}
+    COMMAND ${AWK} "\"/<start>/,/<stop>/\"" ${tmp} > ${tmp2}
+    COMMAND ${AWK} "\"NR>2 {print last} {last=$$0}\"" ${tmp2} > ${actual}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS ${type}.inc m4_type_includes
     )
@@ -56,7 +55,7 @@ foreach(type ${types})
 
   add_test(
     NAME test_derived_${type}
-    COMMAND diff ${expected} ${actual}
+    COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${expected} ${actual}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
 

--- a/include/v2/parameters/tests/CMakeLists.txt
+++ b/include/v2/parameters/tests/CMakeLists.txt
@@ -41,15 +41,23 @@ foreach(type ${types})
   set (tmp2 tmp2_${type}.txt)
   set (actual actual_${type}.txt)
 
-  add_custom_command (
+  if(WIN32)
+    set(AWK_PROG1 "\"/<start>/,/<stop>/\"")
+    set(AWK_PROG2 "\"NR>2 {print last} {last=$$0}\"")
+  else()
+    set(AWK_PROG1 "'/<start>/,/<stop>/'")
+    set(AWK_PROG2 "'NR>2 {print last} {last=$$0}'")
+  endif()
+
+  add_custom_command(
     OUTPUT ${actual}
     COMMAND ${CPP} -traditional -I${GFTL_SOURCE_DIR}/include/v2 -I${GFTL_BINARY_DIR}/include/v2 ${source} > ${tmp}
     # Strip all empty lines and comments
-    COMMAND ${AWK} '/<start>/,/<stop>/' ${tmp} > ${tmp2}
-    COMMAND ${AWK} 'NR>2 {print last} {last=$$0}' ${tmp2} > ${actual}
+    COMMAND ${AWK} ${AWK_PROG1} ${tmp} > ${tmp2}
+    COMMAND ${AWK} ${AWK_PROG2} ${tmp2} > ${actual}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS ${type}.inc m4_type_includes
-    )
+  )
 
   list(APPEND actuals ${actual})
 

--- a/include/v2/parameters/tests/filter.x.in
+++ b/include/v2/parameters/tests/filter.x.in
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-INPUTFILE=$1
-OUTPUTFILE=$2
-
-@AWK@ '/<start>/,/<stop>/' $INPUTFILE | @AWK@ 'NR>2 {print last} {last=$0}' > $OUTPUTFILE
-

--- a/include/v2/templates/CMakeLists.txt
+++ b/include/v2/templates/CMakeLists.txt
@@ -1,8 +1,3 @@
-find_program( M4 m4)
-if( NOT M4 )
-  message( SEND_ERROR "m4 program not found" )
-endif()
-
 install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ DESTINATION "${dest}/include/templates"
     PATTERN CMakeLists.txt EXCLUDE
     PATTERN *~ EXCLUDE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_program(M4 m4)
-
 function (m4_preprocess T infile outfile)
   add_custom_command (
     OUTPUT ${outfile}

--- a/tests/ordered_map/CMakeLists.txt
+++ b/tests/ordered_map/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_program(M4 m4)
-
 # Note that a set of elements of type LOGICAL is not
 # supported.
 set (keys

--- a/tests/vector/CMakeLists.txt
+++ b/tests/vector/CMakeLists.txt
@@ -1,7 +1,5 @@
 #add_subdirectory(sut)
 
-find_program(M4 m4)
-
 set (types
   integer
   integer32


### PR DESCRIPTION
This PR updates the CMake minimum version to 3.24. We choose this as internal use of GFE with MAPL uses 3.24 so we update here for consistency.