### PR TITLE
Fix macro redefinition warnings in template instantiation

### DIFF
--- a/ChangeLog.MD
+++ b/ChangeLog.MD
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed macro redefinition warnings during template instantiation (#268)
+  - Added `#undef` before `#define` in `cpp_copy` m4 macro to prevent warnings when template parameters are copied multiple times
+  - Added conditional `#undef __guard` statements in all container template files to prevent warnings when containers nest other containers (e.g., Map uses Pair, Set uses Vector)
+
 ### Changed
 
 - Remove `gfortran-12` from macos runners, clean up CI

--- a/include/v2/algorithms/procedures.inc
+++ b/include/v2/algorithms/procedures.inc
@@ -1,6 +1,7 @@
 #include "parameters/T/copy_algorithm_T_to_internal_T.inc"
 #include "parameters/T/define_derived_macros.inc"
 
+#undef __guard
 #define __guard __algorithm_guard
 #define __iterator __algorithm_iterator
 #include "algorithms/dir_procedures.inc"
@@ -9,6 +10,7 @@
    
 
 #ifdef __algorithm_riterator
+#  undef __guard
 #  define __guard __IDENTITY(__algorithm_guard)reverse_
 #  define __iterator __algorithm_riterator
 #  include "algorithms/dir_procedures.inc"

--- a/include/v2/algorithms/procedures.inc
+++ b/include/v2/algorithms/procedures.inc
@@ -1,7 +1,6 @@
 #include "parameters/T/copy_algorithm_T_to_internal_T.inc"
 #include "parameters/T/define_derived_macros.inc"
 
-#undef __guard
 #define __guard __algorithm_guard
 #define __iterator __algorithm_iterator
 #include "algorithms/dir_procedures.inc"
@@ -10,7 +9,6 @@
    
 
 #ifdef __algorithm_riterator
-#  undef __guard
 #  define __guard __IDENTITY(__algorithm_guard)reverse_
 #  define __iterator __algorithm_riterator
 #  include "algorithms/dir_procedures.inc"

--- a/include/v2/algorithms/procedures.inc
+++ b/include/v2/algorithms/procedures.inc
@@ -9,6 +9,9 @@
    
 
 #ifdef __algorithm_riterator
+#  if (defined(__guard))
+#    undef __guard
+#  endif
 #  define __guard __IDENTITY(__algorithm_guard)reverse_
 #  define __iterator __algorithm_riterator
 #  include "algorithms/dir_procedures.inc"

--- a/include/v2/algorithms/specification.inc
+++ b/include/v2/algorithms/specification.inc
@@ -1,6 +1,7 @@
 #include "parameters/T/copy_algorithm_T_to_internal_T.inc"
 #include "parameters/T/define_derived_macros.inc"
 
+#undef __guard
 #define __guard __algorithm_guard
 #define __iterator __algorithm_iterator
 #include "algorithms/dir_specification.inc"

--- a/include/v2/algorithms/specification.inc
+++ b/include/v2/algorithms/specification.inc
@@ -1,7 +1,6 @@
 #include "parameters/T/copy_algorithm_T_to_internal_T.inc"
 #include "parameters/T/define_derived_macros.inc"
 
-#undef __guard
 #define __guard __algorithm_guard
 #define __iterator __algorithm_iterator
 #include "algorithms/dir_specification.inc"

--- a/include/v2/algorithms/specification.inc
+++ b/include/v2/algorithms/specification.inc
@@ -1,6 +1,9 @@
 #include "parameters/T/copy_algorithm_T_to_internal_T.inc"
 #include "parameters/T/define_derived_macros.inc"
 
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __algorithm_guard
 #define __iterator __algorithm_iterator
 #include "algorithms/dir_specification.inc"

--- a/include/v2/deque/procedures.inc
+++ b/include/v2/deque/procedures.inc
@@ -15,7 +15,6 @@
 !---------------
 
 #include "parameters/T/copy_deque_T_to_internal_T.inc"
-#undef __guard
 #define __guard __deque_guard
 
 #if defined(__deque_iterator)

--- a/include/v2/deque/procedures.inc
+++ b/include/v2/deque/procedures.inc
@@ -15,6 +15,9 @@
 !---------------
 
 #include "parameters/T/copy_deque_T_to_internal_T.inc"
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __deque_guard
 
 #if defined(__deque_iterator)

--- a/include/v2/deque/procedures.inc
+++ b/include/v2/deque/procedures.inc
@@ -15,6 +15,7 @@
 !---------------
 
 #include "parameters/T/copy_deque_T_to_internal_T.inc"
+#undef __guard
 #define __guard __deque_guard
 
 #if defined(__deque_iterator)

--- a/include/v2/deque/specification.inc
+++ b/include/v2/deque/specification.inc
@@ -15,7 +15,6 @@
 !---------------
 
 #include "parameters/T/copy_deque_T_to_internal_T.inc"
-#undef __guard
 #define __guard __deque_guard
 
 #ifdef __deque_iterator

--- a/include/v2/deque/specification.inc
+++ b/include/v2/deque/specification.inc
@@ -15,6 +15,7 @@
 !---------------
 
 #include "parameters/T/copy_deque_T_to_internal_T.inc"
+#undef __guard
 #define __guard __deque_guard
 
 #ifdef __deque_iterator

--- a/include/v2/deque/specification.inc
+++ b/include/v2/deque/specification.inc
@@ -15,6 +15,9 @@
 !---------------
 
 #include "parameters/T/copy_deque_T_to_internal_T.inc"
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __deque_guard
 
 #ifdef __deque_iterator

--- a/include/v2/map/procedures.inc
+++ b/include/v2/map/procedures.inc
@@ -79,6 +79,9 @@
 #include "parameters/T1/undef_pair_T1.inc"   
 #include "parameters/T2/undef_pair_T2.inc"   
 
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __map_guard
 
 

--- a/include/v2/map/procedures.inc
+++ b/include/v2/map/procedures.inc
@@ -79,6 +79,7 @@
 #include "parameters/T1/undef_pair_T1.inc"   
 #include "parameters/T2/undef_pair_T2.inc"   
 
+#undef __guard
 #define __guard __map_guard
 
 

--- a/include/v2/map/procedures.inc
+++ b/include/v2/map/procedures.inc
@@ -79,7 +79,6 @@
 #include "parameters/T1/undef_pair_T1.inc"   
 #include "parameters/T2/undef_pair_T2.inc"   
 
-#undef __guard
 #define __guard __map_guard
 
 

--- a/include/v2/map/specification.inc
+++ b/include/v2/map/specification.inc
@@ -72,6 +72,9 @@
 #include "parameters/T/undef_set_T.inc"
 
 
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __map_guard
 
 #include "parameters/Key/copy_map_Key_to_internal_Key.inc"

--- a/include/v2/map/specification.inc
+++ b/include/v2/map/specification.inc
@@ -35,43 +35,8 @@
 #include "parameters/T1/undef_pair_T1.inc"   
 #include "parameters/T2/undef_pair_T2.inc"   
 
-   
-   ! Cannot use __MANGLE() for these definitions because the guard
-   ! prefix will be different in the other context.
 
-#ifdef USE_ALT_SET
-#  define __alt_set __IDENTITY(__map_guard)__IDENTITY(__map_set)
-#  define __alt_set_iterator __IDENTITY(__map_guard)__IDENTITY(__map_set_iterator)
-#  define __alt_set_T __map_pair
-#  define __alt_set_T_LT(a,b) __IDENTITY(__map_guard)__IDENTITY(key_less_than)(a,b)
-#  define __alt_set_guard __IDENTITY(__map_guard)__IDENTITY(s_)
-
-#  include "alt_set/specification.inc"
-
-#  undef __alt_set
-#  undef __alt_set_iterator
-#  undef __alt_set_guard
-#  include "parameters/T/undef_alt_set_T.inc"
-
-#else
-
-#  define __set __IDENTITY(__map_guard)__IDENTITY(__map_set)
-#  define __set_iterator __IDENTITY(__map_guard)__IDENTITY(__map_set_iterator)
-#  define __set_T __map_pair
-#  define __set_T_LT(a,b) __IDENTITY(__map_guard)__IDENTITY(key_less_than)(a,b)
-#  define __set_guard __IDENTITY(__map_guard)__IDENTITY(s_)
-
-#  include "set/specification.inc"
-
-#  undef __set
-#  undef __set_iterator
-#  undef __set_guard
-#  include "parameters/T/undef_set_T.inc"
-#endif
-
-#include "parameters/T/undef_set_T.inc"
-
-
+#undef __guard
 #define __guard __map_guard
 
 #include "parameters/Key/copy_map_Key_to_internal_Key.inc"

--- a/include/v2/map/specification.inc
+++ b/include/v2/map/specification.inc
@@ -35,8 +35,43 @@
 #include "parameters/T1/undef_pair_T1.inc"   
 #include "parameters/T2/undef_pair_T2.inc"   
 
+   
+   ! Cannot use __MANGLE() for these definitions because the guard
+   ! prefix will be different in the other context.
 
-#undef __guard
+#ifdef USE_ALT_SET
+#  define __alt_set __IDENTITY(__map_guard)__IDENTITY(__map_set)
+#  define __alt_set_iterator __IDENTITY(__map_guard)__IDENTITY(__map_set_iterator)
+#  define __alt_set_T __map_pair
+#  define __alt_set_T_LT(a,b) __IDENTITY(__map_guard)__IDENTITY(key_less_than)(a,b)
+#  define __alt_set_guard __IDENTITY(__map_guard)__IDENTITY(s_)
+
+#  include "alt_set/specification.inc"
+
+#  undef __alt_set
+#  undef __alt_set_iterator
+#  undef __alt_set_guard
+#  include "parameters/T/undef_alt_set_T.inc"
+
+#else
+
+#  define __set __IDENTITY(__map_guard)__IDENTITY(__map_set)
+#  define __set_iterator __IDENTITY(__map_guard)__IDENTITY(__map_set_iterator)
+#  define __set_T __map_pair
+#  define __set_T_LT(a,b) __IDENTITY(__map_guard)__IDENTITY(key_less_than)(a,b)
+#  define __set_guard __IDENTITY(__map_guard)__IDENTITY(s_)
+
+#  include "set/specification.inc"
+
+#  undef __set
+#  undef __set_iterator
+#  undef __set_guard
+#  include "parameters/T/undef_set_T.inc"
+#endif
+
+#include "parameters/T/undef_set_T.inc"
+
+
 #define __guard __map_guard
 
 #include "parameters/Key/copy_map_Key_to_internal_Key.inc"

--- a/include/v2/ordered_map/procedures.inc
+++ b/include/v2/ordered_map/procedures.inc
@@ -52,7 +52,6 @@
 #undef __vector_guard
 #include "parameters/T/undef_vector_T.inc"
 
-#undef __guard
 #define __guard __omap_guard
 
 #include "parameters/Key/copy_omap_Key_to_internal_Key.inc"

--- a/include/v2/ordered_map/procedures.inc
+++ b/include/v2/ordered_map/procedures.inc
@@ -52,6 +52,7 @@
 #undef __vector_guard
 #include "parameters/T/undef_vector_T.inc"
 
+#undef __guard
 #define __guard __omap_guard
 
 #include "parameters/Key/copy_omap_Key_to_internal_Key.inc"

--- a/include/v2/ordered_map/procedures.inc
+++ b/include/v2/ordered_map/procedures.inc
@@ -52,6 +52,9 @@
 #undef __vector_guard
 #include "parameters/T/undef_vector_T.inc"
 
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __omap_guard
 
 #include "parameters/Key/copy_omap_Key_to_internal_Key.inc"

--- a/include/v2/ordered_map/specification.inc
+++ b/include/v2/ordered_map/specification.inc
@@ -54,6 +54,9 @@
 #include "parameters/T/undef_vector_T.inc"
 
 
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __omap_guard
 
 #include "parameters/Key/copy_omap_Key_to_internal_Key.inc"

--- a/include/v2/ordered_map/specification.inc
+++ b/include/v2/ordered_map/specification.inc
@@ -54,7 +54,6 @@
 #include "parameters/T/undef_vector_T.inc"
 
 
-#undef __guard
 #define __guard __omap_guard
 
 #include "parameters/Key/copy_omap_Key_to_internal_Key.inc"

--- a/include/v2/ordered_map/specification.inc
+++ b/include/v2/ordered_map/specification.inc
@@ -54,6 +54,7 @@
 #include "parameters/T/undef_vector_T.inc"
 
 
+#undef __guard
 #define __guard __omap_guard
 
 #include "parameters/Key/copy_omap_Key_to_internal_Key.inc"

--- a/include/v2/pair/procedures.inc
+++ b/include/v2/pair/procedures.inc
@@ -17,6 +17,7 @@
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T1/copy_pair_T1_to_internal_T1.inc"
 #include "parameters/T2/copy_pair_T2_to_internal_T2.inc"
+#undef __guard
 #define __guard __pair_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/pair/procedures.inc
+++ b/include/v2/pair/procedures.inc
@@ -17,6 +17,9 @@
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T1/copy_pair_T1_to_internal_T1.inc"
 #include "parameters/T2/copy_pair_T2_to_internal_T2.inc"
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __pair_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/pair/procedures.inc
+++ b/include/v2/pair/procedures.inc
@@ -17,7 +17,6 @@
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T1/copy_pair_T1_to_internal_T1.inc"
 #include "parameters/T2/copy_pair_T2_to_internal_T2.inc"
-#undef __guard
 #define __guard __pair_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/pair/specification.inc
+++ b/include/v2/pair/specification.inc
@@ -17,6 +17,7 @@
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T1/copy_pair_T1_to_internal_T1.inc"
 #include "parameters/T2/copy_pair_T2_to_internal_T2.inc"
+#undef __guard
 #define __guard __pair_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/pair/specification.inc
+++ b/include/v2/pair/specification.inc
@@ -17,6 +17,9 @@
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T1/copy_pair_T1_to_internal_T1.inc"
 #include "parameters/T2/copy_pair_T2_to_internal_T2.inc"
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __pair_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/pair/specification.inc
+++ b/include/v2/pair/specification.inc
@@ -17,7 +17,6 @@
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T1/copy_pair_T1_to_internal_T1.inc"
 #include "parameters/T2/copy_pair_T2_to_internal_T2.inc"
-#undef __guard
 #define __guard __pair_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/parameters/cpp_copy.m4
+++ b/include/v2/parameters/cpp_copy.m4
@@ -13,122 +13,35 @@ $#,2,
 
 )
 
-#ifdef _T_out()
-#    undef _T_out()
-#endif
 #define _T_out() _T_in()
 
-#ifdef _T_out()_name
-#    undef _T_out()_name
-#endif
 cpp_copy(name)
 
-#ifdef _T_out()_is_intrinsic
-#    undef _T_out()_is_intrinsic
-#endif
 cpp_copy(is_intrinsic)
-
-#ifdef _T_out()_string
-#    undef _T_out()_string
-#endif
 cpp_copy(string)
 
-#ifdef _T_out()_EQ_SCALAR
-#    undef _T_out()_EQ_SCALAR
-#endif
 cpp_copy(EQ_SCALAR,a,b)
-
-#ifdef _T_out()_NE_SCALAR
-#    undef _T_out()_NE_SCALAR
-#endif
 cpp_copy(NE_SCALAR,a,b)
-
-#ifdef _T_out()_LE_SCALAR
-#    undef _T_out()_LE_SCALAR
-#endif
 cpp_copy(LE_SCALAR,a,b)
-
-#ifdef _T_out()_GE_SCALAR
-#    undef _T_out()_GE_SCALAR
-#endif
 cpp_copy(GE_SCALAR,a,b)
-
-#ifdef _T_out()_LT_SCALAR
-#    undef _T_out()_LT_SCALAR
-#endif
 cpp_copy(LT_SCALAR,a,b)
-
-#ifdef _T_out()_GT_SCALAR
-#    undef _T_out()_GT_SCALAR
-#endif
 cpp_copy(GT_SCALAR,a,b)
 
-#ifdef _T_out()_KINDLEN
-#    undef _T_out()_KINDLEN
-#endif
 cpp_copy(KINDLEN,context)
-
-#ifdef _T_out()_kindlen_dummy
-#    undef _T_out()_kindlen_dummy
-#endif
 cpp_copy(kindlen_dummy)
-
-#ifdef _T_out()_kindlen_component
-#    undef _T_out()_kindlen_component
-#endif
 cpp_copy(kindlen_component)
-
-#ifdef _T_out()_kindlen_string
-#    undef _T_out()_kindlen_string
-#endif
 cpp_copy(kindlen_string)
 
-#ifdef _T_out()_default
-#    undef _T_out()_default
-#endif
 cpp_copy(default)
 
-#ifdef _T_out()_rank
-#    undef _T_out()_rank
-#endif
 cpp_copy(rank)
-
-#ifdef _T_out()_shape
-#    undef _T_out()_shape
-#endif
 cpp_copy(shape)
-
-#ifdef _T_out()_polymorphic
-#    undef _T_out()_polymorphic
-#endif
 cpp_copy(polymorphic)
-
-#ifdef _T_out()_deferred
-#    undef _T_out()_deferred
-#endif
 cpp_copy(deferred)
 
-#ifdef _T_out()_FREE
-#    undef _T_out()_FREE
-#endif
 cpp_copy(FREE,x)
-
-#ifdef _T_out()_COPY
-#    undef _T_out()_COPY
-#endif
 cpp_copy(COPY,lhs,rhs)
-
-#ifdef _T_out()_MOVE
-#    undef _T_out()_MOVE
-#endif
 cpp_copy(MOVE,lhs,rhs)
 
-#ifdef _T_out()_LT
-#    undef _T_out()_LT
-#endif
 cpp_copy(LT,lhs,rhs)
-
-#ifdef _T_out()_EQ
-#    undef _T_out()_EQ
-#endif
 cpp_copy(EQ,lhs,rhs)

--- a/include/v2/parameters/cpp_copy.m4
+++ b/include/v2/parameters/cpp_copy.m4
@@ -13,35 +13,122 @@ $#,2,
 
 )
 
+#ifdef _T_out()
+#    undef _T_out()
+#endif
 #define _T_out() _T_in()
 
+#ifdef _T_out()_name
+#    undef _T_out()_name
+#endif
 cpp_copy(name)
 
+#ifdef _T_out()_is_intrinsic
+#    undef _T_out()_is_intrinsic
+#endif
 cpp_copy(is_intrinsic)
+
+#ifdef _T_out()_string
+#    undef _T_out()_string
+#endif
 cpp_copy(string)
 
+#ifdef _T_out()_EQ_SCALAR
+#    undef _T_out()_EQ_SCALAR
+#endif
 cpp_copy(EQ_SCALAR,a,b)
+
+#ifdef _T_out()_NE_SCALAR
+#    undef _T_out()_NE_SCALAR
+#endif
 cpp_copy(NE_SCALAR,a,b)
+
+#ifdef _T_out()_LE_SCALAR
+#    undef _T_out()_LE_SCALAR
+#endif
 cpp_copy(LE_SCALAR,a,b)
+
+#ifdef _T_out()_GE_SCALAR
+#    undef _T_out()_GE_SCALAR
+#endif
 cpp_copy(GE_SCALAR,a,b)
+
+#ifdef _T_out()_LT_SCALAR
+#    undef _T_out()_LT_SCALAR
+#endif
 cpp_copy(LT_SCALAR,a,b)
+
+#ifdef _T_out()_GT_SCALAR
+#    undef _T_out()_GT_SCALAR
+#endif
 cpp_copy(GT_SCALAR,a,b)
 
+#ifdef _T_out()_KINDLEN
+#    undef _T_out()_KINDLEN
+#endif
 cpp_copy(KINDLEN,context)
+
+#ifdef _T_out()_kindlen_dummy
+#    undef _T_out()_kindlen_dummy
+#endif
 cpp_copy(kindlen_dummy)
+
+#ifdef _T_out()_kindlen_component
+#    undef _T_out()_kindlen_component
+#endif
 cpp_copy(kindlen_component)
+
+#ifdef _T_out()_kindlen_string
+#    undef _T_out()_kindlen_string
+#endif
 cpp_copy(kindlen_string)
 
+#ifdef _T_out()_default
+#    undef _T_out()_default
+#endif
 cpp_copy(default)
 
+#ifdef _T_out()_rank
+#    undef _T_out()_rank
+#endif
 cpp_copy(rank)
+
+#ifdef _T_out()_shape
+#    undef _T_out()_shape
+#endif
 cpp_copy(shape)
+
+#ifdef _T_out()_polymorphic
+#    undef _T_out()_polymorphic
+#endif
 cpp_copy(polymorphic)
+
+#ifdef _T_out()_deferred
+#    undef _T_out()_deferred
+#endif
 cpp_copy(deferred)
 
+#ifdef _T_out()_FREE
+#    undef _T_out()_FREE
+#endif
 cpp_copy(FREE,x)
+
+#ifdef _T_out()_COPY
+#    undef _T_out()_COPY
+#endif
 cpp_copy(COPY,lhs,rhs)
+
+#ifdef _T_out()_MOVE
+#    undef _T_out()_MOVE
+#endif
 cpp_copy(MOVE,lhs,rhs)
 
+#ifdef _T_out()_LT
+#    undef _T_out()_LT
+#endif
 cpp_copy(LT,lhs,rhs)
+
+#ifdef _T_out()_EQ
+#    undef _T_out()_EQ
+#endif
 cpp_copy(EQ,lhs,rhs)

--- a/include/v2/parameters/cpp_copy.m4
+++ b/include/v2/parameters/cpp_copy.m4
@@ -4,6 +4,7 @@ changecom()
 define(`cpp_copy',`
 #ifdef _T_in()_$1
 ! define _T_out()_$1
+#    undef _T_out()_$1
 ifelse($#,1,
 #    define _T_out()_$1 _T_in()_$1,
 $#,2,
@@ -13,6 +14,7 @@ $#,2,
 
 )
 
+#undef _T_out()
 #define _T_out() _T_in()
 
 cpp_copy(name)

--- a/include/v2/ptr/procedures.inc
+++ b/include/v2/ptr/procedures.inc
@@ -16,7 +16,6 @@
 
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T/copy_ptr_T_to_internal_T.inc"
-#undef __guard
 #define __guard __ptr_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/ptr/procedures.inc
+++ b/include/v2/ptr/procedures.inc
@@ -16,6 +16,9 @@
 
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T/copy_ptr_T_to_internal_T.inc"
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __ptr_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/ptr/procedures.inc
+++ b/include/v2/ptr/procedures.inc
@@ -16,6 +16,7 @@
 
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T/copy_ptr_T_to_internal_T.inc"
+#undef __guard
 #define __guard __ptr_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/ptr/specification.inc
+++ b/include/v2/ptr/specification.inc
@@ -10,7 +10,6 @@
 
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T/copy_ptr_T_to_internal_T.inc"
-#undef __guard
 #define __guard __ptr_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/ptr/specification.inc
+++ b/include/v2/ptr/specification.inc
@@ -10,6 +10,9 @@
 
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T/copy_ptr_T_to_internal_T.inc"
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __ptr_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/ptr/specification.inc
+++ b/include/v2/ptr/specification.inc
@@ -10,6 +10,7 @@
 
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T/copy_ptr_T_to_internal_T.inc"
+#undef __guard
 #define __guard __ptr_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/queue/procedures.inc
+++ b/include/v2/queue/procedures.inc
@@ -10,6 +10,7 @@
 
 
 #include "parameters/T/copy_queue_T_to_internal_T.inc"
+#undef __guard
 #define __guard __queue_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/queue/procedures.inc
+++ b/include/v2/queue/procedures.inc
@@ -10,6 +10,9 @@
 
 
 #include "parameters/T/copy_queue_T_to_internal_T.inc"
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __queue_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/queue/procedures.inc
+++ b/include/v2/queue/procedures.inc
@@ -10,7 +10,6 @@
 
 
 #include "parameters/T/copy_queue_T_to_internal_T.inc"
-#undef __guard
 #define __guard __queue_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/queue/specification.inc
+++ b/include/v2/queue/specification.inc
@@ -26,7 +26,6 @@
 
 
 #include "parameters/T/copy_queue_T_to_internal_T.inc"
-#undef __guard
 #define __guard __queue_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/queue/specification.inc
+++ b/include/v2/queue/specification.inc
@@ -26,6 +26,7 @@
 
 
 #include "parameters/T/copy_queue_T_to_internal_T.inc"
+#undef __guard
 #define __guard __queue_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/queue/specification.inc
+++ b/include/v2/queue/specification.inc
@@ -26,6 +26,9 @@
 
 
 #include "parameters/T/copy_queue_T_to_internal_T.inc"
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __queue_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -13,12 +13,10 @@
 !--------------------------------------------------------------------
 
 
-#undef __guard
 #define __guard __set_guard
 #include "parameters/T/copy_set_T_to_internal_T.inc"
 #include "parameters/T/define_derived_macros.inc"
 
-#undef __guard
 #define __guard __set_guard
 
 #define __LEFT 0

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -17,6 +17,9 @@
 #include "parameters/T/copy_set_T_to_internal_T.inc"
 #include "parameters/T/define_derived_macros.inc"
 
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __set_guard
 
 #define __LEFT 0

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -13,14 +13,12 @@
 !--------------------------------------------------------------------
 
 
-#define __guard __set_guard
 #include "parameters/T/copy_set_T_to_internal_T.inc"
-#include "parameters/T/define_derived_macros.inc"
-
 #if (defined(__guard))
 #  undef __guard
 #endif
 #define __guard __set_guard
+#include "parameters/T/define_derived_macros.inc"
 
 #define __LEFT 0
 #define __RIGHT 1

--- a/include/v2/set/procedures.inc
+++ b/include/v2/set/procedures.inc
@@ -13,10 +13,12 @@
 !--------------------------------------------------------------------
 
 
+#undef __guard
 #define __guard __set_guard
 #include "parameters/T/copy_set_T_to_internal_T.inc"
 #include "parameters/T/define_derived_macros.inc"
 
+#undef __guard
 #define __guard __set_guard
 
 #define __LEFT 0

--- a/include/v2/set/specification.inc
+++ b/include/v2/set/specification.inc
@@ -4,10 +4,11 @@
 ! Administration. No copyright is claimed in the United States      |
 ! under Title 17, U.S. Code. All Other Rights Reserved.             |
 !                                                                   |
+! Licensed under the Apache License, Version 2.0.                   |
 !--------------------------------------------------------------------
 
 
-#undef __guard
+
 #define __guard __set_guard
 #include "parameters/T/copy_set_T_to_internal_T.inc"
 #include "parameters/T/define_derived_macros.inc"

--- a/include/v2/set/specification.inc
+++ b/include/v2/set/specification.inc
@@ -4,11 +4,10 @@
 ! Administration. No copyright is claimed in the United States      |
 ! under Title 17, U.S. Code. All Other Rights Reserved.             |
 !                                                                   |
-! Licensed under the Apache License, Version 2.0.                   |
 !--------------------------------------------------------------------
 
 
-
+#undef __guard
 #define __guard __set_guard
 #include "parameters/T/copy_set_T_to_internal_T.inc"
 #include "parameters/T/define_derived_macros.inc"

--- a/include/v2/set/specification.inc
+++ b/include/v2/set/specification.inc
@@ -9,6 +9,9 @@
 
 
 
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __set_guard
 #include "parameters/T/copy_set_T_to_internal_T.inc"
 #include "parameters/T/define_derived_macros.inc"

--- a/include/v2/stack/procedures.inc
+++ b/include/v2/stack/procedures.inc
@@ -10,7 +10,6 @@
 
 
 #include "parameters/T/copy_stack_T_to_internal_T.inc"
-#undef __guard
 #define __guard __stack_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/stack/procedures.inc
+++ b/include/v2/stack/procedures.inc
@@ -10,6 +10,9 @@
 
 
 #include "parameters/T/copy_stack_T_to_internal_T.inc"
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __stack_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/stack/procedures.inc
+++ b/include/v2/stack/procedures.inc
@@ -10,6 +10,7 @@
 
 
 #include "parameters/T/copy_stack_T_to_internal_T.inc"
+#undef __guard
 #define __guard __stack_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/stack/specification.inc
+++ b/include/v2/stack/specification.inc
@@ -26,6 +26,9 @@
 
 
 #include "parameters/T/copy_stack_T_to_internal_T.inc"
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __stack_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/stack/specification.inc
+++ b/include/v2/stack/specification.inc
@@ -26,6 +26,7 @@
 
 
 #include "parameters/T/copy_stack_T_to_internal_T.inc"
+#undef __guard
 #define __guard __stack_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/stack/specification.inc
+++ b/include/v2/stack/specification.inc
@@ -26,7 +26,6 @@
 
 
 #include "parameters/T/copy_stack_T_to_internal_T.inc"
-#undef __guard
 #define __guard __stack_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/vector/procedures.inc
+++ b/include/v2/vector/procedures.inc
@@ -16,6 +16,9 @@
 
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T/copy_vector_T_to_internal_T.inc"
+#if (defined(__guard))
+#  undef __guard
+#endif
 #define __guard __vector_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/vector/procedures.inc
+++ b/include/v2/vector/procedures.inc
@@ -16,6 +16,7 @@
 
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T/copy_vector_T_to_internal_T.inc"
+#undef __guard
 #define __guard __vector_guard
 
 ! define derived generic template parameters from internal parameters.

--- a/include/v2/vector/procedures.inc
+++ b/include/v2/vector/procedures.inc
@@ -16,7 +16,6 @@
 
 ! define generic internal template parameters from pair parameters.
 #include "parameters/T/copy_vector_T_to_internal_T.inc"
-#undef __guard
 #define __guard __vector_guard
 
 ! define derived generic template parameters from internal parameters.


### PR DESCRIPTION
## Summary

This PR fixes annoying preprocessor macro redefinition warnings that occur during template instantiation in gFTL. These warnings appeared when:
1. Template parameters are copied between namespaces multiple times
2. Containers include other containers (e.g., Map uses Pair, Set uses Vector)

## Changes

### 1. Fixed template parameter macro redefinitions

Modified the `cpp_copy` m4 macro in `cpp_copy.m4` to add `#undef` before each `#define`. This ensures that when template parameters are copied from one namespace to another (e.g., `T` → `__vector_T` → `__T`), the target macros are undefined before being redefined.

**Before:**
```fortran
#ifdef T_deferred
#    define __T_deferred T_deferred
#endif
```

**After:**
```fortran
#ifdef T_deferred
#    undef __T_deferred
#    define __T_deferred T_deferred
#endif
```

### 2. Fixed `__guard` macro redefinitions

Added conditional `#undef __guard` statements in all container template files (procedures.inc and specification.inc). The `__guard` macro is used as a unique prefix for mangling template symbols, and must be redefined when containers nest other containers.

**Pattern added:**
```fortran
#if (defined(__guard))
#  undef __guard
#endif
#define __guard __container_guard
```

This matches the existing pattern already used in `alt_set` and `vector` templates, and only undefines the macro if it's already defined, avoiding ordering issues with nested template instantiation.

## Testing

- Builds cleanly with NAG compiler without macro redefinition warnings
- Downstream projects no longer show macro redefinition warnings
- All existing functionality preserved

Fixes #268
